### PR TITLE
Security Dependencies Update

### DIFF
--- a/wiki-service/pom.xml
+++ b/wiki-service/pom.xml
@@ -147,43 +147,10 @@
       <groupId>com.lowagie</groupId>
       <artifactId>itext</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <!-- These bouncycastle artifacts are in conflict with ones used in exo.core.component.document transitive deps (-jdk15 versions) -->
-        <exclusion>
-          <artifactId>bcmail-jdk14</artifactId>
-          <groupId>bouncycastle</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bcprov-jdk14</artifactId>
-          <groupId>bouncycastle</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bctsp-jdk14</artifactId>
-          <groupId>org.bouncycastle</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- To replace the transitive dep of com.lowagie:itext which is in conflict with exo.core.component.document dependencies -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcmail-jdk15</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- To replace the transitive dep of com.lowagie:itext which is in conflict with exo.core.component.document dependencies -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- To replace the transitive dep of com.lowagie:itext which is in conflict with exo.core.component.document dependencies -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctsp-jdk15</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/wiki-webui/pom.xml
+++ b/wiki-webui/pom.xml
@@ -154,44 +154,12 @@
     <dependency>
       <groupId>org.xhtmlrenderer</groupId>
       <artifactId>flying-saucer-pdf</artifactId>
-      <exclusions>
-        <!-- These bouncycastle artifacts are in conflict with ones used in exo.core.component.document transitive deps (-jdk15 versions) -->
-        <exclusion>
-          <artifactId>bcmail-jdk14</artifactId>
-          <groupId>bouncycastle</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bcprov-jdk14</artifactId>
-          <groupId>bouncycastle</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bctsp-jdk14</artifactId>
-          <groupId>org.bouncycastle</groupId>
-        </exclusion>
-      </exclusions>
+      
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <!-- To replace the transitive dep of org.xhtmlrenderer:flying-saucer-pdf which is in conflict with exo.core.component.document dependencies -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcmail-jdk15</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- To replace the transitive dep of org.xhtmlrenderer:flying-saucer-pdf which is in conflict with exo.core.component.document dependencies -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!-- To replace the transitive dep of org.xhtmlrenderer:flying-saucer-pdf which is in conflict with exo.core.component.document dependencies -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctsp-jdk15</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.commons</groupId>


### PR DESCRIPTION
Remove dependencies on
- org.bouncycastle:bcprov-jdk15:1.45
- org.bouncycastle:bcmail-jdk15:1.45
- org.bouncycastle:bctsp-jdk15:1.45
In eXo, we do not need theses dependencies.
bcprov and bcmail are bring by tika-parsers dependency in version 1.67
bctsp is no more needed