### PR TITLE
Task-45860-45861-45889 Improve note front UI in actions menu

### DIFF
--- a/wiki-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/wiki-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -7,6 +7,9 @@ notes.label.addPage=Add Page
 notes.label.editPage=Edit Page
 notes.label.openMenu=Open Menu
 
+notes.menu.label.delete= Delete
+notes.menu.label.copyLink= Copy Link
+
 notes.label.LastModifiedBy=Last modified by {0} at {1}
 btn.cancel= Cancel
 btn.post= Save
@@ -18,7 +21,7 @@ popup.msg.confirmation.DeleteInfo2=Please note:
 popup.msg.confirmation.DeleteInfo3=The removed page has been moved to the trash. Contact your administrator to recover it.
 popup.msg.confirmation.DeleteInfo4=The links to this page will be broken when this page is removed.
 popup.msg.confirmation.DeleteInfo5=This page is child of the page: {1}
-notes.delete= Delete
+
 popup.confirmation= You are about to save an Untitled page.
 popup.ok= Ok
 popup.confirmation.cancel= Are you sure you want to leave this page?
@@ -28,3 +31,8 @@ notes.untitled.title=Untitled
 notes.label.no-content=There is no content for this note...
 notes.label.noteNotFound=We could not find this note.
 notes.label.noteNotFound.button=Back to Notes App
+notes.message.missingTitle=Note title is mandatory
+notes.message.missingLengthTitle=Note title must be between 3 and 1000 characters
+notes.message.error.duplicate.title=Note with same title already exists
+notes.message.error=Response code indicates a server error
+notes.alert.success.label.linkCopied= Note Link copied to clipboard

--- a/wiki-webapp/src/main/webapp/html/notes.html
+++ b/wiki-webapp/src/main/webapp/html/notes.html
@@ -1,5 +1,6 @@
 <div class="VuetifyApp">
   <div id="notesOverviewApplication">
+    <v-cacheable-dom-app cache-id="notesOverviewApplication"></v-cacheable-dom-app>
     <script type="text/javascript">
       require(['PORTLET/wiki/Notes'], app => app.init());
     </script>

--- a/wiki-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/wiki-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -101,8 +101,18 @@
       .notes-title  {
         .notes-header-icons {
           min-width: 100px!important;
+          position: relative;
           button {
             padding: 1px 2px!important;
+          }
+          .note-actions-menu {
+            min-width: 150px!important;
+            right: 7px;
+            top: 25px!important;
+            left: auto!important;
+            .action-menu-item {
+              min-height: 30px!important;
+            }
           }
         }
       }

--- a/wiki-webapp/src/main/webapp/vue-app/notes-switch/initComponents.js
+++ b/wiki-webapp/src/main/webapp/vue-app/notes-switch/initComponents.js
@@ -1,11 +1,13 @@
 import notesFeatureSwitch from './components/NotesFeatureSwitch.vue';
 import notesOverView from '../notes/components/NotesOverview.vue';
 import NoteBreadcrumbDrawer from '../notes/components/NoteBreadcrumbDrawer.vue';
+import NotesActionsMenu from '../notes/components/NotesActionsMenu.vue';
 
 const components = {
   'notes-feature-switch': notesFeatureSwitch,
   'notes-overview': notesOverView,
   'note-breadcrumb-drawer': NoteBreadcrumbDrawer,
+  'notes-actions-menu': NotesActionsMenu
 };
 
 for (const key in components) {

--- a/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesActionsMenu.vue
+++ b/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesActionsMenu.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-menu
+    v-model="displayActionMenu"
+    :attach="'#note-actions-menu'"
+    transition="slide-x-reverse-transition"
+    content-class="note-actions-menu"
+    offset-y
+    left>
+    <v-list>
+      <v-list-item
+        v-if="note.name !== defaultPath"
+        class="px-2 text-left action-menu-item draftButton"
+        @click="$root.$emit('delete-note')">
+        <v-icon
+          size="19"
+          class="primary--text clickable pr-2">
+          mdi-trash-can-outline
+        </v-icon>
+        <span>{{ $t('notes.menu.label.delete') }}</span>
+      </v-list-item>
+      <v-list-item
+        class="px-2 text-left action-menu-item draftButton"
+        @click="copyLink">
+        <v-icon
+          size="19"
+          class="primary--text clickable pr-2">
+          mdi-link-variant
+        </v-icon>
+        <span>{{ $t('notes.menu.label.copyLink') }}</span>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      displayActionMenu: false,
+    };
+  },
+  props: {
+    note: {
+      type: Object,
+      default: () => null,
+    },
+    defaultPath: {
+      type: String,
+      default: () => 'WikiHome',
+    }
+  },
+  created() {
+    $(document).on('mousedown', () => {
+      if (this.displayActionMenu) {
+        window.setTimeout(() => {
+          this.displayActionMenu = false;
+        }, this.waitTimeUntilCloseMenu);
+      }
+    });
+    this.$root.$on('display-action-menu', ( )=> {
+      this.displayActionMenu = true;
+    });
+  },
+  methods: {
+    copyLink() {
+      const inputTemp = $('<input>');
+      const path = window.location.href;
+      $('body').append(inputTemp);
+      inputTemp.val(path).select();
+      document.execCommand('copy');
+      inputTemp.remove();
+      this.$root.$emit('show-alert', {type: 'success',message: this.$t('notes.alert.success.label.linkCopied')});
+    }
+  },
+};
+</script>

--- a/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -81,13 +81,13 @@
               </template>
               <span class="caption">{{ $t('notes.label.noteTreeview.tooltip') }}</span>
             </v-tooltip>
-            <div v-if="notes.breadcrumb.length <= 4" class="notes-tree-items d-flex">
+            <div v-if="notebreadcrumb.length <= 4" class="notes-tree-items d-flex">
               <div
-                v-for="(note, index) in notes.breadcrumb"
+                v-for="(note, index) in notebreadcrumb"
                 :key="index"
-                :class="notes.breadcrumb.length === 1 && 'single-path-element' || ''"
+                :class="notebreadcrumb.length === 1 && 'single-path-element' || ''"
                 class="notes-tree-item d-flex text-truncate"
-                :style="`max-width: ${100 / (notes.breadcrumb.length)}%`">
+                :style="`max-width: ${100 / (notebreadcrumb.length)}%`">
                 <v-tooltip max-width="300" bottom>
                   <template v-slot:activator="{ on, attrs }">
                     <a 
@@ -95,11 +95,11 @@
                       v-on="on"
                       @click="getNoteById(note.id)"
                       class="caption text-truncate "
-                      :class="index < notes.breadcrumb.length-1 && 'path-clickable text-color' || 'text-sub-title not-clickable'">{{ note.title }}</a>
+                      :class="index < notebreadcrumb.length-1 && 'path-clickable text-color' || 'text-sub-title not-clickable'">{{ note.title }}</a>
                   </template>
                   <span class="caption">{{ note.title }}</span>
                 </v-tooltip>
-                <v-icon v-if="index < notes.breadcrumb.length-1" size="18">mdi-chevron-right</v-icon>
+                <v-icon v-if="index < notebreadcrumb.length-1" size="18">mdi-chevron-right</v-icon>
               </div>
             </div>
             <div v-else class="notes-tree-items notes-long-path d-flex align-center">
@@ -110,9 +110,9 @@
                       class="caption text-color text-truncate path-clickable"
                       v-bind="attrs"
                       v-on="on"
-                      @click="getNoteById(notes.breadcrumb[0].id)">{{ notes.breadcrumb[0].title }}</a>
+                      @click="getNoteById(notebreadcrumb[0].id)">{{ notebreadcrumb[0].title }}</a>
                   </template>
-                  <span class="caption">{{ notes.breadcrumb[0].title }}</span>
+                  <span class="caption">{{ notebreadcrumb[0].title }}</span>
                 </v-tooltip>
                 <v-icon size="18">mdi-chevron-right</v-icon>
               </div>
@@ -127,10 +127,10 @@
                     </v-icon>
                   </template>
                   <p
-                    v-for="(note, index) in notes.breadcrumb"
+                    v-for="(note, index) in notebreadcrumb"
                     :key="index"
                     class="mb-0">
-                    <span v-if="index > 0 && index <notes.breadcrumb.length-2" class="caption"><v-icon size="18" class="tooltip-chevron">mdi-chevron-right</v-icon> {{ note.title }}</span>
+                    <span v-if="index > 0 && index <notebreadcrumb.length-2" class="caption"><v-icon size="18" class="tooltip-chevron">mdi-chevron-right</v-icon> {{ note.title }}</span>
                   </p>
                 </v-tooltip>
                 <v-icon class="clickable" size="18">mdi-chevron-right</v-icon>
@@ -142,9 +142,9 @@
                       class="caption text-color text-truncate path-clickable"
                       v-bind="attrs"
                       v-on="on"
-                      @click="getNoteById(notes.breadcrumb[notes.breadcrumb.length-2].id)">{{ notes.breadcrumb[notes.breadcrumb.length-2].title }}</a>
+                      @click="getNoteById(notebreadcrumb[notebreadcrumb.length-2].id)">{{ notebreadcrumb[notebreadcrumb.length-2].title }}</a>
                   </template>
-                  <span class="caption">{{ notes.breadcrumb[notes.breadcrumb.length-2].title }}</span>
+                  <span class="caption">{{ notebreadcrumb[notebreadcrumb.length-2].title }}</span>
                 </v-tooltip>
                 <v-icon size="18">mdi-chevron-right</v-icon>
               </div>
@@ -155,9 +155,9 @@
                       class="caption text-color text-truncate text-sub-title"
                       v-bind="attrs"
                       v-on="on"
-                      @click="getNoteById(notes.breadcrumb[notes.breadcrumb.length-1].id)">{{ notes.breadcrumb[notes.breadcrumb.length-1].title }}</a>
+                      @click="getNoteById(notebreadcrumb[notebreadcrumb.length-1].id)">{{ notebreadcrumb[notebreadcrumb.length-1].title }}</a>
                   </template>
-                  <span class="caption">{{ notes.breadcrumb[notes.breadcrumb.length-1].title }}</span>
+                  <span class="caption">{{ notebreadcrumb[notebreadcrumb.length-1].title }}</span>
                 </v-tooltip>
               </div>
             </div>
@@ -227,19 +227,21 @@ export default {
       displayActionMenu: false,
       parentPageName: '',
       confirmMessage: '',
-      breadcrumbNotes: '',
+      //breadcrumbNotes: '',
       noteBookType: eXo.env.portal.spaceName ? 'group' : 'portal',
       noteBookOwner: eXo.env.portal.spaceName ? `/spaces/${eXo.env.portal.spaceName}` : `${eXo.env.portal.portalName}`,
       noteBookOwnerTree: eXo.env.portal.spaceName ? `spaces/${eXo.env.portal.spaceName}` : `${eXo.env.portal.portalName}`,
       noteNotFountImage: '/wiki/skin/images/notes_not_found.png',
       defaultPath: 'WikiHome',
-      existingNote: false,
-      currentPath: window.location.pathname
+      existingNote: true,
+      currentPath: window.location.pathname, 
+      currentNoteBreadcrumb: []
     };
   },
   watch: {
     notes() {
       this.lastUpdatedUser = this.retrieveUserInformations(this.notes.author);
+      this.currentNoteBreadcrumb = this.notes.breadcrumb;
       this.lastUpdatedTime = this.notes.updatedDate.time && this.$dateUtil.formatDateObjectToDisplay(new Date(this.notes.updatedDate.time), this.dateTimeFormat, this.lang) || '';
     }
   },
@@ -253,6 +255,9 @@ export default {
 
     isAvailableNote() {
       return this.existingNote;
+    },
+    notebreadcrumb() {
+      return this.currentNoteBreadcrumb;
     },
     notesPageName() {
       if (this.currentPath.endsWith('/wiki')){
@@ -302,23 +307,10 @@ export default {
     },
     deleteNotes(){
       this.$notesService.deleteNotes(this.notes).then(() => {
-        this.refreshNote();
+        this.getNoteById(this.notebreadcrumb[ this.notebreadcrumb.length-2].id);
       }).catch(e => {
         console.error('Error when deleting notes', e);
       });
-    },
-    refreshNote(){
-      this.$notesService.getNoteById('1').then(data => {
-        window.location.href=this.$notesService.getPathByNoteOwner(data);
-      });
-    },
-    getParentsNotes(){
-      this.breadcrumbNotes = '';
-      for (let index = 0; index < this.notes.breadcrumb.length-1; index++) {
-        this.parentPageName=this.notes.breadcrumb[index].id;
-        this.breadcrumbNotes = this.breadcrumbNotes.concat(this.notes.breadcrumb[index].title,' > ');
-      }
-      return this.breadcrumbNotes;
     },
     retrieveUserInformations(userName) {
       this.$userService.getUser(userName).then(user => {
@@ -328,8 +320,14 @@ export default {
     getNotes(noteBookType,noteBookOwner,notesPageName) {
       return this.$notesService.getNotes(noteBookType, noteBookOwner , notesPageName).then(data => {
         this.notes = data || [];
-        this.existingNote = true;
+        return this.$nextTick();
+      }).catch(e => {
+        console.error('Error when getting notes', e);
+        this.existingNote = false;
+      }).finally(() => {
+        this.$root.$emit('application-loaded');
       });
+      
     },
     getNoteTree() {
       return this.$notesService.getNoteTree(this.noteBookType, this.noteBookOwnerTree , this.notesPageName,'ALL').then(data => {
@@ -371,7 +369,13 @@ export default {
       return activatedNotes;
     },
     confirmDeleteNote: function () {
-      this.getParentsNotes();
+      let parentsBreadcrumb = '';
+      for (let index = 0; index < this.notebreadcrumb.length-1; index++) {
+        parentsBreadcrumb = parentsBreadcrumb.concat(this.notebreadcrumb[index].title);
+        if (index < this.notebreadcrumb.length-2) {
+          parentsBreadcrumb = parentsBreadcrumb.concat('>');
+        }
+      }
       this.confirmMessage = `${this.$t('popup.msg.confirmation.DeleteInfo1', {
         0: `<b>${this.notes && this.notes.title}</b>`,
       })
@@ -380,7 +384,7 @@ export default {
           + `<li>${this.$t('popup.msg.confirmation.DeleteInfo3')}</li>`
           + `<li>${this.$t('popup.msg.confirmation.DeleteInfo4')}</li>`
           + `<li>${this.$t('popup.msg.confirmation.DeleteInfo5', {
-            1: `<b>${this.breadcrumbNotes}</b>`,
+            1: `<b>${parentsBreadcrumb}</b>`,
           })}</li>`;
       this.$refs.DeleteNoteDialog.open();
     },

--- a/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -5,7 +5,7 @@
         <div class="notes-application-header">
           <div class="notes-title d-flex justify-space-between">
             <span class="title text-color mt-n1">{{ notes.title }}</span>
-            <div class="notes-header-icons text-right">
+            <div id="note-actions-menu" class="notes-header-icons text-right">
               <v-tooltip bottom>
                 <template v-slot:activator="{ on, attrs }">
                   <v-icon
@@ -34,40 +34,19 @@
                 <span class="caption">{{ $t('notes.label.editPage') }}</span>
               </v-tooltip>
 
-              <v-menu
-                v-if="notes.name !== defaultPath"
-                v-model="displayActionMenu"
-                transition="slide-x-reverse-transition"
-                offset-y
-                left>
-                <template v-slot:activator="{ on: menu, attrs }">
-                  <v-tooltip bottom>
-                    <template v-slot:activator="{ on: tooltip }">
-                      <v-icon
-                        size="19"
-                        class="clickable"
-                        v-bind="attrs"
-                        v-on="{ ...tooltip, ...menu }"
-                        @click="displayActionMenu = true">
-                        mdi-dots-vertical
-                      </v-icon>
-                    </template>
-                    <span class="caption">{{ $t('notes.label.openMenu') }}</span>
-                  </v-tooltip>
+              <v-tooltip bottom>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon
+                    size="19"
+                    class="clickable"
+                    v-bind="attrs"
+                    v-on="on"
+                    @click="$root.$emit('display-action-menu')">
+                    mdi-dots-vertical
+                  </v-icon>
                 </template>
-                <v-list>
-                  <v-list-item
-                    v-if="notes.name !== defaultPath"
-                    class="draftButton"
-                    :key="notes.id"
-                    @click="confirmDeleteNote">
-                    <v-list-item-title class="subtitle-2">
-                      <i class="uiIcon uiIconTrash pr-1"></i>
-                      <span>{{ $t('notes.delete') }}</span>
-                    </v-list-item-title>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
+                <span class="caption">{{ $t('notes.label.openMenu') }}</span>
+              </v-tooltip>
             </div>
           </div>
           <div class="notes-treeview d-flex flex-wrap pb-2">
@@ -194,6 +173,7 @@
         </a>
       </div>
     </div>
+    <notes-actions-menu :note="notes" :default-path="defaultPath" />
     <note-breadcrumb-drawer 
       ref="notesBreadcrumb" />
     <exo-confirm-dialog
@@ -206,6 +186,12 @@
       @ok="deleteNotes()"
       @dialog-opened="$emit('confirmDialogOpened')"
       @dialog-closed="$emit('confirmDialogClosed')" />
+    <v-alert
+      v-model="alert"
+      :type="type"
+      dismissible>
+      {{ message }}
+    </v-alert>
   </v-app>
 </template>
 <script>
@@ -227,7 +213,6 @@ export default {
       displayActionMenu: false,
       parentPageName: '',
       confirmMessage: '',
-      //breadcrumbNotes: '',
       noteBookType: eXo.env.portal.spaceName ? 'group' : 'portal',
       noteBookOwner: eXo.env.portal.spaceName ? `/spaces/${eXo.env.portal.spaceName}` : `${eXo.env.portal.portalName}`,
       noteBookOwnerTree: eXo.env.portal.spaceName ? `spaces/${eXo.env.portal.spaceName}` : `${eXo.env.portal.portalName}`,
@@ -235,7 +220,10 @@ export default {
       defaultPath: 'WikiHome',
       existingNote: true,
       currentPath: window.location.pathname, 
-      currentNoteBreadcrumb: []
+      currentNoteBreadcrumb: [],
+      alert: false,
+      type: '',
+      message: '',
     };
   },
   watch: {
@@ -277,13 +265,6 @@ export default {
     }
   },
   created() {
-    $(document).on('mousedown', () => {
-      if (this.displayActionMenu) {
-        window.setTimeout(() => {
-          this.displayActionMenu = false;
-        }, this.waitTimeUntilCloseMenu);
-      }
-    });
     this.$root.$on('open-note', notePath => {
       const noteName = notePath.split('%2F').pop();
       this.getNotes(this.noteBookType, this.noteBookOwner , noteName);
@@ -293,6 +274,12 @@ export default {
     });
     this.$root.$on('open-note-by-id', noteId => {
       this.getNoteById(noteId);
+    });
+    this.$root.$on('confirmDeleteNote', () => {
+      this.confirmDeleteNote();
+    });
+    this.$root.$on('show-alert', message => {
+      this.displayMessage(message);
     });
   },
   mounted() {
@@ -388,6 +375,12 @@ export default {
           })}</li>`;
       this.$refs.DeleteNoteDialog.open();
     },
+    displayMessage(message) {
+      this.message=message.message;
+      this.type=message.type;
+      this.alert = true;
+      window.setTimeout(() => this.alert = false, 5000);
+    }
   }
 };
 </script>

--- a/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/wiki-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -35,6 +35,7 @@
               </v-tooltip>
 
               <v-menu
+                v-if="notes.name !== defaultPath"
                 v-model="displayActionMenu"
                 transition="slide-x-reverse-transition"
                 offset-y
@@ -56,6 +57,7 @@
                 </template>
                 <v-list>
                   <v-list-item
+                    v-if="notes.name !== defaultPath"
                     class="draftButton"
                     :key="notes.id"
                     @click="confirmDeleteNote">

--- a/wiki-webapp/src/main/webapp/vue-app/notes/initComponents.js
+++ b/wiki-webapp/src/main/webapp/vue-app/notes/initComponents.js
@@ -1,8 +1,11 @@
 import NotesOverview from './components/NotesOverview.vue';
 import NoteBreadcrumbDrawer from './components/NoteBreadcrumbDrawer.vue';
+import NotesActionsMenu from './components/NotesActionsMenu.vue';
+
 const components = {
   'notes-overview': NotesOverview,
   'note-breadcrumb-drawer': NoteBreadcrumbDrawer,
+  'notes-actions-menu': NotesActionsMenu
 };
 
 for (const key in components) {

--- a/wiki-webapp/src/main/webapp/vue-app/notes/main.js
+++ b/wiki-webapp/src/main/webapp/vue-app/notes/main.js
@@ -27,11 +27,13 @@ window.Object.defineProperty(Vue.prototype, '$notesService', {
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+    const appElement = document.createElement('div');
+    appElement.id = appId;
     // init Vue app when locale ressources are ready
     new Vue({
-      template: `<notes-overview id="${appId}" />`,
+      template: `<notes-overview v-cacheable id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(`#${appId}`);
+    }).$mount(appElement);
   });
 }


### PR DESCRIPTION
Backport PR: [https://github.com/Meeds-io/notes/pull/60/](https://github.com/Meeds-io/notes/pull/60/) ,[https://github.com/Meeds-io/notes/pull/61]( https://github.com/Meeds-io/notes/pull/61), [https://github.com/Meeds-io/notes/pull/64](https://github.com/Meeds-io/notes/pull/64)

- DeleteNote_US03: Remove delete button from wiki home page
- [BUG] Switch from Old to New UI is linked toDisplay of page not found 
- CollaborativeActions_US02: Copy link for Notes application