### PR TITLE
Update security Fix : update forgotten groupId

### DIFF
--- a/wiki-service/pom.xml
+++ b/wiki-service/pom.xml
@@ -174,7 +174,7 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <scope>test</scope>
       <exclusions>


### PR DESCRIPTION
The groupId for dom4j was forgotten in the last security-fix commit