### PR TITLE
Task-46110 Fix display note page when having long content

### DIFF
--- a/wiki-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/wiki-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -100,11 +100,9 @@
 .notesApplication {
   max-width: 100%;
   .notes-wrapper {
-    height: calc(~"100vh - 170px");
     min-height: calc(~"100vh - 170px");
   }
   .notes-application {
-    height: calc(~"100vh - 170px");
     min-height: calc(~"100vh - 170px");
     .notes-application-header {
       .notes-title  {


### PR DESCRIPTION
[BUG] [TRIBE-3031] Display of Note page content is not OK after Switch from old UI to new UI.
When creating a Note page with long content then switch from old UI to new UI the display of whole page is not Ok.