### PR TITLE
TASK-47074 Fix Generated Notes Activity Stream Owner

### DIFF
--- a/wiki-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/wiki-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -424,7 +424,7 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
         if (space != null) {
           if (!isPublicInSpace(page, space))
             return;
-          ownerStream = identityManager.getOrCreateUserIdentity(space.getPrettyName());
+          ownerStream = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
           spaceUrl = space.getUrl();
           spaceName = space.getDisplayName();
         }

--- a/wiki-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/wiki-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -1,14 +1,17 @@
 package org.exoplatform.wiki.ext.impl;
 
+import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.exoplatform.wiki.mow.api.Page;
-import org.exoplatform.wiki.service.PageUpdateType;
-import org.exoplatform.wiki.service.WikiService;
+import org.exoplatform.wiki.mow.api.*;
+import org.exoplatform.wiki.service.*;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +20,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.*;
+
+import java.util.Collections;
 
 /**
  * Test class for WikiSpaceActivityPublisher
@@ -93,6 +98,44 @@ public class WikiSpaceActivityPublisherTest {
     // only get first 4 lines of wiki page WIKI-1290
     String exceprt = activity.getTemplateParams().get("page_exceprt");
     Assert.assertEquals("<p>line1</p><p>line2</p><p>line3</p><p>line4</p>...", exceprt);
+  }
+
+  @Test
+  public void shouldSaveActivityInSpaceStream() throws Exception {
+    String spaceGroupId = "/spaces/space1";
+    String spacePrettyName = "space1";
+
+    Page page = new Page();
+    page.setContent("line1\n\nline2\n\nline3\n\nline4\n\nline5");
+    Permission wikiPagePermission = new Permission();
+    wikiPagePermission.setAllowed(true);
+    wikiPagePermission.setPermissionType(PermissionType.VIEWPAGE);
+    Permission[] permissions = new Permission[] { wikiPagePermission };
+    page.setPermissions(Collections.singletonList(new PermissionEntry(spaceGroupId, null, IDType.GROUP, permissions)));
+
+    prepareMockServices(page);
+
+    Space space = new Space();
+    space.setGroupId(spaceGroupId);
+    space.setPrettyName(spacePrettyName);
+    space.setDisplayName(spacePrettyName);
+
+    org.exoplatform.social.core.identity.model.Identity spaceIdentity = new org.exoplatform.social.core.identity.model.Identity(SpaceIdentityProvider.NAME,
+                                                                                                                              spacePrettyName);
+
+    when(spaceService.getSpaceByGroupId(spaceGroupId)).thenReturn(space);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(spaceIdentity);
+
+    // save activity
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+                                                                                           identityManager,
+                                                                                           activityManager,
+                                                                                           spaceService);
+    wikiSpaceActivityPublisher.saveActivity(PortalConfig.GROUP_TYPE, spaceGroupId, "page1", page, PageUpdateType.ADD_PAGE);
+    // check if activity manager saveActivityNoReturn is called
+    ArgumentCaptor<ExoSocialActivity> activityCaptor = ArgumentCaptor.forClass(ExoSocialActivity.class);
+    verify(activityManager).saveActivityNoReturn(eq(spaceIdentity),
+                                                 activityCaptor.capture());
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, the activities of notes pages are published on User/Creator Stream instead of Space Stream. This fix ensures that the generated activities about spaces pages are created in space Stream instead of User stream that is visible by relationships of user