### PR TITLE
Task-45373: Fix Notes application name and description are not displayed by their value in space settings interface (#144)

### DIFF
--- a/notes-service/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/notes-service/src/main/resources/locale/portlet/Portlets_en.properties
@@ -1,0 +1,2 @@
+SpaceSettings.application.notes.application.title=Notes Application
+SpaceSettings.application.notes.application.description=Notes


### PR DESCRIPTION
Problem: the Notes application name and description are not displayed by their values in space settings interface.
How it was solved: by adding the Portlets_en.properties file which will configure the default values of name and description of Notes app.