### PR TITLE
Task-36455: Fix technical label for notes notification

### DIFF
--- a/notes-service/src/main/resources/locale/wiki/service/WikiService_en.properties
+++ b/notes-service/src/main/resources/locale/wiki/service/WikiService_en.properties
@@ -15,6 +15,8 @@ UINotification.label.group.wiki=Notes
 UINotification.label.EditWikiNotificationPlugin=Notes
 Notification.subject.EditWikiNotificationPlugin=$WIKI_PAGE_NAME page was modified by $USER.
 
+UINotification.title.EditWikiNotificationPlugin=Edit note
+
 Notification.wiki.web.editWikiNotification=The watched Notes page {0} has been edited by {1}
 Notification.wiki.mail.wikiChangeNotification=Changes
 Notification.wiki.mail.editWikiNotification=The page {0} has been edited by {1}, you are receiving this notification because you are watching this page.


### PR DESCRIPTION
Problem: the note label description didn't exist in the .properties file from which it will be read and displayed.
How it was solved: add the note label description of the title and give it the value that will be displayed.