### PR TITLE
Task-48426: Missing label for the title of note editor page

### DIFF
--- a/notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties
@@ -17,3 +17,6 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 portal.global.wiki=Notes
+portal.global.notes-editor= Notes Editor
+portal.global.notes=Notes
+portal.global.noteHome=Home

--- a/notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties
@@ -17,6 +17,6 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 portal.global.wiki=Notes
-portal.global.notes-editor= Notes Editor
+portal.global.notes-editor=Notes Editor
 portal.global.notes=Notes
 portal.global.noteHome=Home

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -1,9 +1,6 @@
 #Portlet notes
 notes.title.placeholderContentInput= Title
 notes.body.placeholderContentInput= Body
-portal.global.notes-editor= Notes Editor
-portal.global.notes=Notes
-portal.global.noteHome=Home
 notes.label.addPage=Add Page
 notes.label.editPage=Edit Page
 notes.label.openMenu=Open Menu


### PR DESCRIPTION
Prio this change , a technical label on the title of note editor page is displayed
Fix : move translation label  to navigation.portal.global.properties file.