### PR TITLE
Task-47220: Inconsistence of WYSIWYG in Table display (#148)

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -153,11 +153,14 @@
   .notes-wrapper {
     min-height: calc(~"100vh - 170px");
   }
+  .notes-application-content {
+    overflow: auto;
+  }
   table{
-	table-layout: fixed;
-	width: 100%;
-	word-break: break-all;
-	border: 1px solid var(--allPagesBorderColor,#e1e8ee);
+    width: auto;
+    td {
+      padding: 5px;
+    }
   }
   .notes-application {
     min-height: calc(~"100vh - 170px");


### PR DESCRIPTION
When a table does have a long text, some words are cut and the line break is in the middle of the words.
This PR fix it