### PR TITLE
Task-48426: Missing label for the title of note editor page

### DIFF
--- a/notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties
@@ -19,4 +19,3 @@
 portal.global.wiki=Notes
 portal.global.notes-editor=Notes Editor
 portal.global.notes=Notes
-portal.global.noteHome=Home

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -1,6 +1,7 @@
 #Portlet notes
 notes.title.placeholderContentInput= Title
 notes.body.placeholderContentInput= Body
+notes.label.noteHome=Home
 notes.label.addPage=Add Page
 notes.label.editPage=Edit Page
 notes.label.openMenu=Open Menu

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
@@ -221,7 +221,7 @@ export default {
       if (this.movePage) {
         this.$notesService.getNotes(this.note.wikiType, this.note.wikiOwner , note.id).then(data => {
           this.breadcrumb = data && data.breadcrumb || []; 
-          this.breadcrumb[0].name = this.$t('portal.global.noteHome');
+          this.breadcrumb[0].name = this.$t('notes.label.noteHome');
           this.destinationNote = data;      
         });
       }
@@ -248,7 +248,7 @@ export default {
       if (id) {
         return this.$notesService.getNoteById(id).then(data => {
           this.note = data || [];
-          this.note.breadcrumb[0].title = this.$t('portal.global.noteHome');
+          this.note.breadcrumb[0].title = this.$t('notes.label.noteHome');
           this.breadcrumb = this.note.breadcrumb;
         }).then(() => {
           if (this.note.wikiType === 'group'){
@@ -266,7 +266,7 @@ export default {
         this.openNotes = openedTreeviewItem;
         this.activeItem = [openedTreeviewItem[openedTreeviewItem.length-1]];
         this.breadcrumbItems = noteChildren;
-        this.breadcrumbItems[0].name = this.$t('portal.global.noteHome');
+        this.breadcrumbItems[0].name = this.$t('notes.label.noteHome');
         this.noteBookType = noteType;
         this.noteBookOwnerTree = noteOwner;
       });

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -158,7 +158,7 @@ export default {
     notes() {
       this.lastUpdatedUser = this.retrieveUserInformations(this.notes.author);
       if ( this.notes && this.notes.breadcrumb && this.notes.breadcrumb.length ) {
-        this.notes.breadcrumb[0].title = this.$t('portal.global.noteHome');
+        this.notes.breadcrumb[0].title = this.$t('notes.label.noteHome');
         this.currentNoteBreadcrumb = this.notes.breadcrumb;
       }
       this.lastUpdatedTime = this.notes.updatedDate.time && this.$dateUtil.formatDateObjectToDisplay(new Date(this.notes.updatedDate.time), this.dateTimeFormat, this.lang) || '';
@@ -183,7 +183,7 @@ export default {
     },
     noteTitle() {
       if ( this.noteId === 1) {
-        return this.$t('portal.global.noteHome');
+        return this.$t('notes.label.noteHome');
       } else {
         return this.notes.title;
       }


### PR DESCRIPTION
Prio this change , a technical label on the title of note editor page is displayed
Fix : move translation label to navigation.portal.global.properties file.