### PR TITLE
Task-48344 : When searching a wiki page in renamed space, the URL of the result do not display the page

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
@@ -581,6 +581,7 @@ public class WikiRestServiceImpl implements ResourceContainer {
       for (SearchResult searchResult : results) {
         org.exoplatform.wiki.mow.api.Page page = wikiService.getPageOfWikiByName(searchResult.getWikiType(), searchResult.getWikiOwner(), searchResult.getPageName());
         if(page != null) {
+          page.setUrl(Utils.getPageUrl(page));
           if (SearchResultType.ATTACHMENT.equals(searchResult.getType())) {
             org.exoplatform.wiki.mow.api.Attachment attachment = wikiService.getAttachmentOfPageByName(searchResult.getAttachmentName(), page);
             titleSearchResults.add(new TitleSearchResult(attachment.getName(), searchResult.getType(), attachment.getDownloadURL()));

--- a/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -687,6 +687,6 @@ public class Utils {
     } catch (Exception e) {
       log_.warn("Cannot get Wiki App anme");
     }
-    return "wiki";
+    return "notes";
   }
 }


### PR DESCRIPTION
When I search for Notes in the unified search the notes URL does not exist, and when I rename the space the URL is not correct
My proposed solution is to build the URL every time I do the search