### PR TITLE
MAINT-47146: Fix the display of table properties command in the context menu to be only available when right clicking on a table

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -301,19 +301,19 @@ export default {
 
             CKEDITOR.instances['notesContent'].contextMenu.addListener( function( element ) {
               if ( element.getAscendant( 'table', true ) ) {
+                CKEDITOR.instances['notesContent'].addCommand('tableProperties', {
+                  exec: function() {
+                    if (CKEDITOR.instances['notesContent'].elementPath() && CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 )){
+                      const table=CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 ).getAttributes();
+                      self.$refs.noteTablePlugins.open(table);
+                    }
+                  }
+                });
                 return {
                   tableProperties: CKEDITOR.TRISTATE_ON
                 };
               }});
-            CKEDITOR.instances['notesContent'].addCommand('tableProperties', {
-              exec: function() {
-                if (CKEDITOR.instances['notesContent'].elementPath() && CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 )){
-                  const table=CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 ).getAttributes();
-                  self.$refs.noteTablePlugins.open(table);
-                }
 
-              }
-            });
             $(CKEDITOR.instances['notesContent'].document.$)
               .find('.atwho-inserted')
               .each(function() {


### PR DESCRIPTION
**ISSUE**: The invoke of the custom table properties ckeditor command were not placed correctly in the code which will be triggered with no condition if the targeted element is a table.
**FIX**: Correctly place the table properties command execution to be only on table elements.