### PR TITLE
MAINT-47146: remove table properties  from context menu item when right click on a non table element

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -312,7 +312,11 @@ export default {
                 return {
                   tableProperties: CKEDITOR.TRISTATE_ON
                 };
-              }});
+              } else {
+                const items = CKEDITOR.instances['notesContent'].contextMenu.items;
+                CKEDITOR.instances['notesContent'].contextMenu.items = $.grep(items, (item) => item.command !== 'tableProperties');
+              }
+            });
 
             $(CKEDITOR.instances['notesContent'].document.$)
               .find('.atwho-inserted')


### PR DESCRIPTION

**ISSUE**: after adding the menu item table properties when inserting a table is doesn't get removed from the menu items even when clicking on other elements.
**FIX**: remove it from the items when right click a non table element