### PR TITLE
Task-48889: Insert options drawer still opened after insert image

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
@@ -96,6 +96,7 @@ export default {
         this.$root.$emit('display-treeview-items');
       } else {
         this.instance.execCommand(id);
+        this.close();
       }
     }
   }


### PR DESCRIPTION
After execCommand of insert image or video plugin, we should close the drawer of insert options