### PR TITLE
MAINT-47146: Fix the display of table properties command in the context menu to be only available when right clicking on a table

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -301,19 +301,19 @@ export default {
 
             CKEDITOR.instances['notesContent'].contextMenu.addListener( function( element ) {
               if ( element.getAscendant( 'table', true ) ) {
+                CKEDITOR.instances['notesContent'].addCommand('tableProperties', {
+                  exec: function() {
+                    if (CKEDITOR.instances['notesContent'].elementPath() && CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 )){
+                      const table=CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 ).getAttributes();
+                      self.$refs.noteTablePlugins.open(table);
+                    }
+                  }
+                });
                 return {
                   tableProperties: CKEDITOR.TRISTATE_ON
                 };
               }});
-            CKEDITOR.instances['notesContent'].addCommand('tableProperties', {
-              exec: function() {
-                if (CKEDITOR.instances['notesContent'].elementPath() && CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 )){
-                  const table=CKEDITOR.instances['notesContent'].elementPath().contains( 'table', 1 ).getAttributes();
-                  self.$refs.noteTablePlugins.open(table);
-                }
 
-              }
-            });
             $(CKEDITOR.instances['notesContent'].document.$)
               .find('.atwho-inserted')
               .each(function() {

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -312,7 +312,11 @@ export default {
                 return {
                   tableProperties: CKEDITOR.TRISTATE_ON
                 };
-              }});
+              } else {
+                const items = CKEDITOR.instances['notesContent'].contextMenu.items;
+                CKEDITOR.instances['notesContent'].contextMenu.items = $.grep(items, (item) => item.command !== 'tableProperties');
+              }
+            });
 
             $(CKEDITOR.instances['notesContent'].document.$)
               .find('.atwho-inserted')


### PR DESCRIPTION
ISSUE: after adding the menu item table properties when inserting a table is doesn't get removed from the menu items even when clicking on other elements.
FIX: remove it from the items when right click a non table element