### PR TITLE
Task-46383: Space applications name translation is missing (#253)

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/Portlets_en.properties
@@ -1,0 +1,9 @@
+#############################################################################
+#SpaceApplications
+#############################################################################
+
+SpaceSettings.application.wiki.title=Notes
+SpaceSettings.application.wiki.description=Wiki Portlet
+
+SpaceSettings.application.notes.application.title=Notes
+SpaceSettings.application.notes.application.description=Notes Application

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -79,13 +79,3 @@ notes.label.Index=Index
 notes.label.IFrame=IFrame
 notes.label.Code=Code
 
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ar.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ar.properties
@@ -529,15 +529,6 @@ resource.url.label=\u0639\u0646\u0648\u0627\u0646 \u0627\u0644\u0645\u0648\u0642
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u0627\u0644\u0645\u0633\u062A\u062E\u062F\u0645
 resource.user.placeholder=\u0627\u0644\u0643\u0646\u064A\u0629
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=\u0648\u064A\u0643\u064A
-SpaceSettings.application.wiki.description=\u0645\u062F\u062E\u0644 \u0648\u064A\u0643\u064A
-
-SpaceSettings.application.notes.application.title=\u0648\u064A\u0643\u064A
-SpaceSettings.application.notes.application.description=\u062A\u0637\u0628\u064A\u0642 \u0627\u0644\u0645\u0644\u0627\u062D\u0638\u0627\u062A
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_aro.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_aro.properties
@@ -529,15 +529,6 @@ resource.url.label=\u0639\u0646\u0648\u0627\u0646 \u0627\u0644\u0645\u0648\u0642
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u0627\u0644\u0645\u0633\u062A\u062E\u062F\u0645
 resource.user.placeholder=\u0627\u0644\u0643\u0646\u064A\u0629
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=\u0648\u064A\u0643\u064A
-SpaceSettings.application.wiki.description=\u0645\u062F\u062E\u0644 \u0648\u064A\u0643\u064A
-
-SpaceSettings.application.notes.application.title=\u0648\u064A\u0643\u064A
-SpaceSettings.application.notes.application.description=\u062A\u0637\u0628\u064A\u0642 \u0627\u0644\u0645\u0644\u0627\u062D\u0638\u0627\u062A
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_az.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_az.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u0130stifad\u0259\u00E7i
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ca.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ca.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Usuari
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ceb.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ceb.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_co.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_co.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_cs.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_cs.properties
@@ -529,16 +529,6 @@ resource.url.label=ADRESA URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=U\u017Eivatel
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_de.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_de.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Benutzer
 resource.user.placeholder=Aliasname
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notizen
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notizen
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_el.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_el.properties
@@ -529,15 +529,6 @@ resource.url.label=\u0394\u03B9\u03B5\u03CD\u03B8\u03C5\u03BD\u03C3\u03B7 URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u03A7\u03C1\u03AE\u03C3\u03C4\u03B7\u03C2
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_es_ES.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_es_ES.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.ejemplo.org/imagen.png
 resource.user.label=Usuario
 resource.user.placeholder=apodo
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notas
-SpaceSettings.application.wiki.description=Portlet de la Wiki
-
-SpaceSettings.application.notes.application.title=Notas
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_eu.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_eu.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fa.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fa.properties
@@ -529,15 +529,6 @@ resource.url.label=\u0622\u062F\u0631\u0633
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u06A9\u0627\u0631\u0628\u0631
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fi.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fil.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fil.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Ang gumagamit
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.exemple.fr/image.png
 resource.user.label=Utilisateur
 resource.user.placeholder=Alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Application Notes
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Application de notes
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hi.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hu.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hu.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_in.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_in.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Pengguna
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_it.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_it.properties
@@ -529,6 +529,7 @@ resource.url.label=Url
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Utente
 resource.user.placeholder=alias
+<<<<<<< HEAD
 #############################################################################
 #SpaceApplications
 #############################################################################
@@ -538,6 +539,8 @@ SpaceSettings.application.wiki.description=Wiki Portlet
 
 SpaceSettings.application.notes.application.title=Wiki
 SpaceSettings.application.notes.application.description=Notes Application
+=======
+>>>>>>> 1575eea2 (Task-46383: Space applications name translation is missing (#253))
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ja.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ja.properties
@@ -529,6 +529,7 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u30E6\u30FC\u30B6\u30FC
 resource.user.placeholder=alias
+<<<<<<< HEAD
 #############################################################################
 #SpaceApplications
 #############################################################################
@@ -538,6 +539,8 @@ SpaceSettings.application.wiki.description=Wiki Portlet
 
 SpaceSettings.application.notes.application.title=Notes
 SpaceSettings.application.notes.application.description=Notes Application
+=======
+>>>>>>> 1575eea2 (Task-46383: Space applications name translation is missing (#253))
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_kab.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_kab.properties
@@ -529,6 +529,7 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
+<<<<<<< HEAD
 #############################################################################
 #SpaceApplications
 #############################################################################
@@ -538,6 +539,8 @@ SpaceSettings.application.wiki.description=Wiki Portlet
 
 SpaceSettings.application.notes.application.title=Notes
 SpaceSettings.application.notes.application.description=Notes Application
+=======
+>>>>>>> 1575eea2 (Task-46383: Space applications name translation is missing (#253))
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ko.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ko.properties
@@ -529,6 +529,7 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
+<<<<<<< HEAD
 #############################################################################
 #SpaceApplications
 #############################################################################
@@ -538,6 +539,8 @@ SpaceSettings.application.wiki.description=Wiki Portlet
 
 SpaceSettings.application.notes.application.title=Notes
 SpaceSettings.application.notes.application.description=Notes Application
+=======
+>>>>>>> 1575eea2 (Task-46383: Space applications name translation is missing (#253))
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_lt.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_lt.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Vartotojas
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ms.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ms.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_nl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_nl.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=#{word.user}
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_no.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_no.properties
@@ -529,15 +529,6 @@ resource.url.label=Nettadresse
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Bruker
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pcm.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pcm.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pl.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=U\u017Cytkownik
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_BR.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_BR.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Usu\u00E1rio
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_PT.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_PT.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Utilizador
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ro.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ro.properties
@@ -529,16 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Utilizator
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
-
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ru.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ru.properties
@@ -529,15 +529,6 @@ resource.url.label=URL-\u0430\u0434\u0440\u0435\u0441
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u044C
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sk.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sk.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sl.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Uporabnik
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sq.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sq.properties
@@ -529,12 +529,6 @@ resource.url.label=crwdns6937064:0crwdne6937064:0
 resource.url.placeholder=crwdns6937066:0crwdne6937066:0
 resource.user.label=crwdns6937068:0crwdne6937068:0
 resource.user.placeholder=crwdns6937070:0crwdne6937070:0
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=crwdns6989208:0crwdne6989208:0
-SpaceSettings.application.wiki.description=crwdns6989210:0crwdne6989210:0
 
 #####################################################################################
 #                                    Vue Notes                        #

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sv_SE.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sv_SE.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=Anv\u00E4ndare
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_th.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_th.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tl.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tr.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.ornek.org/resim.png
 resource.user.label=Kullan\u0131c\u0131
 resource.user.placeholder=takma ad
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Wiki
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Wiki
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_uk.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_uk.properties
@@ -529,15 +529,6 @@ resource.url.label=URL-\u0430\u0434\u0440\u0435\u0441\u0430
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u041A\u043E\u0440\u0438\u0441\u0442\u0443\u0432\u0430\u0447
 resource.user.placeholder=\u0410\u043B\u0456\u0430\u0441
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Wiki
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Wiki
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ur_IN.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ur_IN.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=User
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_vi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_vi.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=T\u00EAn Ng\u01B0\u1EDDi d\u00F9ng
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_CN.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_CN.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u7528\u6237
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_TW.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_TW.properties
@@ -529,15 +529,6 @@ resource.url.label=URL
 resource.url.placeholder=http://www.example.org/image.png
 resource.user.label=\u4F7F\u7528\u8005
 resource.user.placeholder=alias
-#############################################################################
-#SpaceApplications
-#############################################################################
-
-SpaceSettings.application.wiki.title=Notes
-SpaceSettings.application.wiki.description=Wiki Portlet
-
-SpaceSettings.application.notes.application.title=Notes
-SpaceSettings.application.notes.application.description=Notes Application
 
 
 #####################################################################################

--- a/translations.properties
+++ b/translations.properties
@@ -26,6 +26,8 @@ service/integration.properties=notes-social-integration/src/main/resources/local
 service/WikiNotification.properties=notes-social-integration/src/main/resources/locale/wiki/integration/notification/WikiNotification_en.properties
 
 webapp/WikiPortlet.properties=notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+webapp/NotesPortlet.properties=notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+webapp/Portlet.properties=notes-webapp/src/main/resources/locale/portlet/Portlets_en.properties
 
 # portal
 portal/global.properties=notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties


### PR DESCRIPTION
Prior this fix, the space application name display as a technical labels