### PR TITLE
Task-47335 : Add target blank to external links

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -185,7 +185,7 @@ export default {
   },
   computed: {
     noteVersionContent() {
-      return this.noteContent;
+      return this.noteContent && this.targetBlank(this.noteContent);
     },
     lastNoteVersion() {
       if ( this.displayLastVersion ) {
@@ -424,7 +424,24 @@ export default {
         .finally(() => {
           this.getNoteVersionByNoteId(this.note.id);
         });
-    }
+    },
+    targetBlank: function (content) {
+      const internal = location.host + eXo.env.portal.context;
+      const domParser = new DOMParser();
+      const docElement = domParser.parseFromString(content, 'text/html').documentElement;
+      const links = docElement.getElementsByTagName('a');
+      for (const link of links) {
+        let href = link.href.replace(/(^\w+:|^)\/\//, '');
+        if (href.endsWith('/')) {
+          href = href.slice(0, -1);
+        }
+        if (href !== location.host && !href.startsWith(internal)) {
+          link.setAttribute('target', '_blank');
+          link.setAttribute('rel', 'noopener noreferrer');
+        }
+      }
+      return docElement.innerHTML;
+    },
   }
 };
 </script>


### PR DESCRIPTION
Before this fix when we click on external link in the note, it opened in the same tab.
So we add target _blank when there is an external link.
