### PR TITLE
MAINT-48844:Preventx tooltip displaying on mobile view

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -266,7 +266,7 @@
           position: relative;
 
           button {
-            padding: 1px 2px !important;
+            padding: 1px 2px;
           }
 
           .note-actions-menu {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
@@ -9,12 +9,18 @@
         :style="`max-width: ${100 / (noteBreadcrumb.length)}%`">
         <v-tooltip max-width="300" bottom>
           <template v-slot:activator="{ on, attrs }">
-            <a 
+            <v-btn
+              height="20px"
+              min-width="45px"
+              class="pa-0"
+              text
               v-bind="attrs"
               v-on="on"
-              @click="$emit('open-note',note.id)"
-              class="caption text-truncate breadCrumb-link"
-              :class="index < noteBreadcrumb.length-1 && 'path-clickable text-color' || 'text-sub-title not-clickable'">{{ note.title }}</a>
+              @click="$emit('open-note',note.id)">
+              <a
+                class="caption text-truncate breadCrumb-link"
+                :class="index < noteBreadcrumb.length-1 && 'path-clickable text-color' || 'text-sub-title not-clickable'">{{ note.title }}</a>
+            </v-btn>
           </template>
           <span class="caption">{{ note.title }}</span>
         </v-tooltip>

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -7,65 +7,85 @@
         ref="content">
         <div class="notes-application-header">
           <div class="notes-title d-flex justify-space-between">
-            <span class="title text-color mt-n1">{{ note.title }}</span>
+            <span class="title text-color mt-1">{{ note.title }}</span>
             <div
               id="note-actions-menu"
               v-show="loadData && !hideActions"
               class="notes-header-icons text-right">
               <v-tooltip bottom v-if="!isMobile && !note.draftPage && note.canManage">
                 <template v-slot:activator="{ on, attrs }">
-                  <v-icon
-                    size="22"
-                    class="clickable add-note-click"
-                    @click="addNote"
+                  <v-btn
+                    class="pa-0"
+                    v-on="on"
                     v-bind="attrs"
-                    v-on="on">
-                    mdi-plus
-                  </v-icon>
+                    @click="addNote"
+                    icon>
+                    <v-icon
+                      size="22"
+                      class="clickable add-note-click">
+                      mdi-plus
+                    </v-icon>
+                  </v-btn>
                 </template>
                 <span class="caption">{{ $t('notes.label.addPage') }}</span>
               </v-tooltip>
               <v-tooltip bottom v-if="note.canManage && !isMobile">
                 <template v-slot:activator="{ on, attrs }">
-                  <v-icon
-                    size="19"
-                    class="clickable edit-note-click"
-                    @click="editNote"
+                  <v-btn
+                    class="pa-0"
+                    icon
+                    v-on="on"
                     v-bind="attrs"
-                    v-on="on">
-                    mdi-square-edit-outline
-                  </v-icon>
+                    @click="editNote">
+                    <v-icon
+                      size="19"
+                      class="clickable edit-note-click">
+                      mdi-square-edit-outline
+                    </v-icon>
+                  </v-btn>
                 </template>
                 <span class="caption">{{ $t('notes.label.editPage') }}</span>
               </v-tooltip>
 
               <v-tooltip bottom>
                 <template v-slot:activator="{ on, attrs }">
-                  <v-icon
-                    size="19"
-                    class="clickable"
-                    v-bind="attrs"
+                  <v-btn
+                    class="pa-0"
                     v-on="on"
-                    @click="$root.$emit('display-action-menu')">
-                    mdi-dots-vertical
-                  </v-icon>
+                    @click="$root.$emit('display-action-menu')"
+                    v-bind="attrs"
+                    icon>
+                    <v-icon
+                      size="19"
+                      class="clickable">
+                      mdi-dots-vertical
+                    </v-icon>
+                  </v-btn>
                 </template>
                 <span class="caption">{{ $t('notes.label.openMenu') }}</span>
               </v-tooltip>
             </div>
           </div>
-          <div class="notes-treeview d-flex flex-wrap pb-2">
+          <div class="notes-treeview d-flex flex-inline">
             <v-tooltip bottom>
               <template v-slot:activator="{ on, attrs }">
-                <i 
-                  class="uiIcon uiTreeviewIcon primary--text me-3"
+                <v-btn
+                  @click="$refs.notesBreadcrumb.open(note, 'displayNote')"
+                  v-on="on"
+                  class="pa-0"
+                  min-width="24"
                   v-bind="attrs"
-                  v-on="on" 
-                  @click="$refs.notesBreadcrumb.open(note, 'displayNote')"></i>
+                  text>
+                  <i
+                    class="uiIcon uiTreeviewIcon primary--text"></i>
+                </v-btn>
               </template>
               <span class="caption">{{ $t('notes.label.noteTreeview.tooltip') }}</span>
             </v-tooltip>
-            <note-breadcrumb :note-breadcrumb="notebreadcrumb" @open-note="getNoteByName($event, 'breadCrumb')" />
+            <note-breadcrumb
+              class="pt-2 pe-1 pl-1"
+              :note-breadcrumb="notebreadcrumb"
+              @open-note="getNoteByName($event, 'breadCrumb')" />
           </div>
           <div class="notes-last-update-info">
             <span class="note-version border-radius primary px-2 font-weight-bold me-2 caption clickable" @click="openNoteVersionsHistoryDrawer(noteVersions, note.canManage)">V{{ lastNoteVersion }}</span>


### PR DESCRIPTION
ISSUE: when using v-tooltip on any element it will be displayed on hover and click event except the v-btn element which is triggered only on hover event
FIX: Use the v-btn element instead as a wokaround because this issue comes from vuetify itself.