### PR TITLE
Fix/Task-49217: When exporting a note make sure To display only the title in the header section.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -7,7 +7,7 @@
         ref="content">
         <div class="notes-application-header">
           <div class="notes-title d-flex justify-space-between pb-4">
-            <span class="title text-color mt-n1">{{ $t('note.label.home') }}  {{ spaceDisplayName }}</span>
+            <span ref="noteTitle" class="title text-color mt-n1">{{ $t('note.label.home') }}  {{ spaceDisplayName }}</span>
             <div
               id="note-actions-menu"
               v-show="loadData && !hideElementsForSavingPDF"
@@ -451,12 +451,15 @@ export default {
     },
     createPDF(note) {
       this.hideElementsForSavingPDF = true;
+      this.$refs.noteTitle.innerHTML = note.title;
+      const self = this;
       this.$nextTick(() => {
         const element = this.$refs.content;
         this.hideElementsForSavingPDF = false;
         html2canvas(element, {
           useCORS: true
         }).then(function (canvas) {
+          self.$refs.noteTitle.innerHTML = `${self.$t('note.label.home')} ${self.spaceDisplayName}`;
           const pdf = new JSPDF('p', 'mm', 'a4');
           const ctx = canvas.getContext('2d');
           const a4w = 170;


### PR DESCRIPTION
Once validated this commit will be squashed with the original one before merge to develop.