### PR TITLE
Task-50320: [Fix Regression] make sure to display the correct filter of tree view drawer when exporting notes.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -609,7 +609,6 @@ export default {
         if (CKEDITOR.instances['notesContent']) {
           CKEDITOR.instances['notesContent'].status = 'ready';
           window.setTimeout(() => {
-            console.log('Test: ', CKEDITOR.instances['notesContent']);
             this.$nextTick().then(() => CKEDITOR.instances['notesContent'].focus());
           }, 200);
         }        

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
@@ -319,8 +319,10 @@ export default {
     open(note, source, includeDisplay) {
       this.render = false;
       if (note.draftPage) {
+        this.filter = this.filterOptions[1];
         this.getDraftNote(note.id);
       } else {
+        this.filter = this.filterOptions[0];
         this.getNoteById(note.id);
       }
       if (source === 'includePages') {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-app class="transparent" flat role="main">
+  <v-app 
+    class="transparent"
+    role="main"
+    flat>
     <div>
       <div
         v-if="isAvailableNote"
@@ -130,10 +133,10 @@
     <notes-actions-menu
       :note="note"
       :default-path="defaultPath" 
-      @open-treeview="$refs.notesBreadcrumb.open(note.id, 'movePage')"
+      @open-treeview="$refs.notesBreadcrumb.open(note, 'movePage')"
       @export-pdf="createPDF(note)"
       @open-history="$refs.noteVersionsHistoryDrawer.open(noteVersions,note.canManage)"
-      @open-treeview-export="$refs.notesBreadcrumb.open(note.id, 'exportNotes')" />
+      @open-treeview-export="$refs.notesBreadcrumb.open(note, 'exportNotes')" />
     <note-treeview-drawer
       ref="notesBreadcrumb" />
     <note-history-drawer


### PR DESCRIPTION
Issue: when opening the drawer to export notes the filter is not updated so the retrieved nods are draft notes if filter is set to 'drafts'.
Fix: These changes make sure to update filter on need when opening the drawer from menu actions. 