### PR TITLE
MAINT-49275: Fix the inability to show edit option when accessing the Notes app from top space navigation

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -55,6 +55,7 @@ import org.exoplatform.wiki.utils.Utils;
 
 import io.swagger.annotations.*;
 import io.swagger.jaxrs.PATCH;
+import org.exoplatform.wiki.utils.WikiConstants;
 
 @Path("/notes")
 @Api(value = "/notes", description = "Managing notes")
@@ -98,9 +99,10 @@ public class NotesRestService implements ResourceContainer {
         noteBook = noteBookService.createWiki(noteBookType, noteBookOwner);
       }
       Page note = null;
-      if(noteId.equals("homeNote")){
-        note = noteBook.getWikiHome();
-      }else{
+      if (noteId.equals(WikiConstants.WIKI_NEW_HOME_NAME) || noteId.equals(WikiConstants.WIKI_HOME_NAME)) {
+        noteId = noteBook.getWikiHome().getId();
+        note = noteService.getNoteById(noteId, identity, source);
+      } else {
         note = noteService.getNoteOfNoteBookByName(noteBookType, noteBookOwner, noteId, identity, source);
       }
       if (note == null) {

--- a/notes-service/src/main/java/org/exoplatform/wiki/utils/WikiConstants.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/utils/WikiConstants.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.utils;
 
 public interface WikiConstants {
 
-  public static final String WIKI_HOME_NAME     = "Home";
-
-  public static final String WIKI_HOME_TITLE    = "Home";
+  String WIKI_HOME_NAME     = "Home";
+  String WIKI_NEW_HOME_NAME = "homeNote";
+  String WIKI_HOME_TITLE    = "Home";
 }


### PR DESCRIPTION
**ISSUE** : When accessing the Notes app from top bar space menu the edit option of the home page is not shown unless you refresh the page because of a wrong getting of the home Note.
**FIX**: Fix the getting of the home Note page