### PR TITLE
Task-51620 : Add aria-label on save button when creating note

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -28,6 +28,7 @@
                 id="notesUpdateAndPost"
                 class="btn btn-primary primary px-2 py-0"
                 :key="postKey"
+                :aria-label="publishButtonText"
                 @click.once="postNote(false)">
                 {{ publishButtonText }}
                 <v-icon


### PR DESCRIPTION
Before this fix, the save button for notes does not respect RGAA Criteria 11.9 :
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-11-9
This commit add the aria-label attribute on this button to make it compliant