### PR TITLE
Task-52445: Re-implement exportNotes method in order to add the ability of exporting independent notes.

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/mow/api/NoteToExport.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/mow/api/NoteToExport.java
@@ -16,14 +16,14 @@
  */
 package org.exoplatform.wiki.mow.api;
 
-import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.LinkedList;
 import java.util.List;
 
-import org.exoplatform.wiki.service.BreadcrumbData;
-
-import lombok.Data;
-
-@Data
+@Getter
+@Setter
 public class NoteToExport {
 
   private String id;
@@ -52,6 +52,8 @@ public class NoteToExport {
 
   private NoteToExport parent;
 
+  private LinkedList<String> ancestors;
+
   public NoteToExport() {
   }
 
@@ -59,7 +61,7 @@ public class NoteToExport {
     this.name = name;
   }
 
-  public NoteToExport(String id,String name, String owner, String author, String content, String syntax, String title, String comment, String wikiId, String wikiType, String wikiOwner) {
+  public NoteToExport(String id, String name, String owner, String author, String content, String syntax, String title, String comment, String wikiId, String wikiType, String wikiOwner) {
     this();
     this.id = id;
     this.name = name;
@@ -72,6 +74,23 @@ public class NoteToExport {
     this.wikiId = wikiId;
     this.wikiType = wikiType;
     this.wikiOwner = wikiOwner;
+  }
+
+  public NoteToExport(NoteToExport noteToExport) {
+    this.id = noteToExport.getId();
+    this.name = noteToExport.getName();
+    this.owner = noteToExport.getOwner();
+    this.author = noteToExport.getAuthor();
+    this.content = noteToExport.getContent();
+    this.syntax = noteToExport.getSyntax();
+    this.title = noteToExport.getTitle();
+    this.comment = noteToExport.getComment();
+    this.wikiId = noteToExport.getWikiId();
+    this.wikiType = noteToExport.getWikiType();
+    this.wikiOwner = noteToExport.getWikiOwner();
+    this.children = noteToExport.getChildren();
+    this.parent = noteToExport.getParent();
+    this.ancestors = noteToExport.getAncestors();
   }
 
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/mow/api/Page.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/mow/api/Page.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.wiki.mow.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.exoplatform.social.metadata.model.MetadataItem;
@@ -27,6 +28,7 @@ import java.util.Map;
 
 @Data
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Page {
 
   private String id;

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
@@ -16,12 +16,13 @@
  */
 package org.exoplatform.wiki.service;
 
-import java.io.IOException;
-import java.util.List;
-import org.gatein.api.EntityNotFoundException;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.mow.api.*;
+import org.gatein.api.EntityNotFoundException;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Provides functions for processing database with notes, including: adding,
@@ -345,16 +346,16 @@ public interface NoteService {
   /**
    * Creates a draft for a new page
    *
-   * @param draftNoteToSave The draft note to be created
+   * @param draftNoteToSave   The draft note to be created
    * @param currentTimeMillis
    * @return Created draft
    * @throws WikiException
    */
   DraftPage createDraftForNewPage(DraftPage draftNoteToSave, long currentTimeMillis) throws WikiException;
 
-  byte[] exportNotes(String[] notes, boolean exportChildren, Identity identity) throws IOException, WikiException;
+  byte[] exportNotes(String[] notesToExportIds, boolean exportAll, Identity identity) throws IOException, WikiException;
 
-  List<NoteToExport> getNotesToExport(String[] notes, boolean exportChildren, Identity identity);
+  List<NoteToExport> getNotesToExport(String[] notesToExportIds, boolean exportAll, Identity identity);
 
   List<NoteToExport> getChildrenNoteOf(NoteToExport note) throws WikiException;
 
@@ -363,6 +364,6 @@ public interface NoteService {
   void importNotes(String zipLocation, Page parent, String conflict, Identity userIdentity) throws WikiException, IllegalAccessException, IOException;
 
   void importNotes(List<String> files, Page parent, String conflict, Identity userIdentity) throws WikiException,
-                                                                                                   IllegalAccessException,
-                                                                                                   IOException;
+          IllegalAccessException,
+          IOException;
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -713,12 +713,12 @@ public class NotesRestService implements ResourceContainer {
       @ApiResponse(code = 400, message = "Invalid query input"), @ApiResponse(code = 403, message = "Unauthorized operation"),
       @ApiResponse(code = 404, message = "Resource not found") })
   public Response exportNote(@ApiParam(value = "List of notes ids", required = true) @PathParam("notes") String notesList,
-                             @ApiParam(value = "exportChildren") @QueryParam("exportChildren") Boolean exportChildren) {
+                             @ApiParam(value = "exportAll") @QueryParam("exportAll") Boolean exportAll) {
 
     try {
       Identity identity = ConversationState.getCurrent().getIdentity();
       String[] notes = notesList.split(",");
-      byte[] filesBytes = noteService.exportNotes(notes, exportChildren,identity);
+      byte[] filesBytes = noteService.exportNotes(notes, exportAll,identity);
       return Response.ok(filesBytes)
                      .type("application/zip")
                      .header("Content-Disposition", "attachment; filename=\"notesExport_" + new Date().getTime() + ".zip\"")

--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
@@ -274,8 +274,8 @@ export function importZipNotes(noteId,uploadId,overrideMode) {
 }
 
 
-export function exportNotes(notes,exportChildren) {
-  return fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/note/export/${notes}?exportChildren=${exportChildren}`, {
+export function exportNotes(notes,exportAll) {
+  return fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/note/export/${notes}?exportAll=${exportAll}`, {
     credentials: 'include',
     method: 'GET',
   }).then((resp) => {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -527,28 +527,26 @@ export default {
         });
       });
     },
-    exportNotes(notesSelected,importAll,homeNoteId){
-      let exportChildren =false;
-      if (importAll === true) {
-        exportChildren = true;
+    exportNotes(notesSelected, exportAll, homeNoteId) {
+      if (exportAll) {
         notesSelected = homeNoteId;
       }
-      const date=this.$dateUtil.formatDateObjectToDisplay(Date.now(), this.dateTimeFormatZip, this.lang);
-      this.$notesService.exportNotes(notesSelected,exportChildren).then((transfer) => {
+      const date = this.$dateUtil.formatDateObjectToDisplay(Date.now(), this.dateTimeFormatZip, this.lang);
+      this.$notesService.exportNotes(notesSelected, exportAll).then((transfer) => {
         return transfer.blob();
       }).then((bytes) => {
-        const elm = document.createElement('a');  
+        const elm = document.createElement('a');
         elm.href = URL.createObjectURL(bytes);
         elm.setAttribute('download', `${date}_notes_${this.spaceDisplayName}.zip`);
-        elm.click();                             
+        elm.click();
         this.$root.$emit('close-note-tree-drawer');
-        this.$root.$emit('show-alert', {type: 'success',message: this.$t('notes.alert.success.label.exported')});
-      }).catch(e=> {
+        this.$root.$emit('show-alert', {type: 'success', message: this.$t('notes.alert.success.label.exported')});
+      }).catch(e => {
         console.error('Error when export note page', e);
         this.$root.$emit('show-alert', {
           type: 'error',
           message: this.$t(`notes.message.${e.message}`)
-        });          
+        });
       });
     },
     getNoteById(noteId, source) {


### PR DESCRIPTION
Currently the export notes functionality doesn't allow to export notes independently which means that when exporting a note, its parent is automatically selected in the notes to export, and so it is not possible to export a parent note independently since when selecting a note all its children are selected.
These changes add the ability to export notes independently which allows also to restructure the tree note to export according to selection.
For example: we have tree note:
home > Note01 > Note01.1 > Note01.1.1
     > Note01.2
     > Note02 > Note02.1
     > Note02.2
when selecting notes (Note01, Note01.1.1, Note02.2) to be exported
the result tree would be:
home > Note01 > Note01.1.1
     > Note02.2
and so.