### PR TITLE
TASK-52696 : Technical label on mouse over of a Note

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/wikiSearch/components/WikiSearchCard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/wikiSearch/components/WikiSearchCard.vue
@@ -35,7 +35,7 @@
         <v-list-item-content>
           <v-list-item-title :title="wikiTitle">
             <a
-              :title="wikiTitle"
+              :title="wikiTitleText"
               class="wikiTitle px-3 pt-2 pb-1 ps-0 text-start text-truncate"
               v-html="wikiTitle">
             </a>
@@ -84,6 +84,9 @@ export default {
     },
     wikiTitle() {
       return this.result && this.result.title || '';
+    },
+    wikiTitleText() {
+      return $('<div />').html(this.wikiTitle).text();
     },
     poster() {
       return this.result && this.result.poster.profile;


### PR DESCRIPTION
ISSUE : while searching for some notes using the main search bar, the note's title displayed as html form instead of simple text form.

FIX : converting the title from a html to a simple text form while hovering on it and keeping its html form to be displayed before the hover action.