### PR TITLE
Task-52643: Make sure that when saving a new note the according draft note is well deleted.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -422,7 +422,6 @@ export default {
             // delete draft note
             const draftNote = JSON.parse(localStorage.getItem(`draftNoteId-${this.note.id}`));
             this.deleteDraftNote(draftNote, notePath);
-            window.location.href = notePath;
           }).catch(e => {
             console.error('Error when creating note page', e);
             this.enableClickOnce();


### PR DESCRIPTION
Issue: the previously added window.location.href code line comes just after the call to the deleteDraftNote function which contains a fetch call, which makes the fetch call aborted and throws an error: "TypeError: NetworkError when attempting to fetch resource".
Reproduced only on FireFox.
Fix: I removed this line of code since it is already set in the promise's resolve of the fetch call response in the function deleteDraftNote.