### PR TITLE
TASK-50337 : bad behavior when using the notes app while the space's name contains 'notes' word

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -555,9 +555,7 @@ export default {
         this.note = data || {};
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
-        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
-        window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
+        this.updateURL();
         return this.$nextTick();
       }).catch(e => {
         console.error('Error when getting note', e);
@@ -591,9 +589,7 @@ export default {
         this.note = data || {};
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
-        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
-        window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
+        this.updateURL();
         return this.$nextTick();
       }).catch(e => {
         console.error('Error when getting note', e);
@@ -617,9 +613,7 @@ export default {
         this.isDraft = true;
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
-        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
-        window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
+        this.updateURL();
         return this.$nextTick();
       }).catch(e => {
         console.error('Error when getting note', e);
@@ -806,6 +800,11 @@ export default {
           console.error('Error when update note page', e);
         });
       }
+    },
+    updateURL(){
+      const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
+      notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
+      window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
     }
   }
 };

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -555,7 +555,8 @@ export default {
         this.note = data || {};
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.split(this.appName)[0]}${this.appName}/${this.note.id}`;
+        const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
+        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
         window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
         return this.$nextTick();
       }).catch(e => {
@@ -590,7 +591,8 @@ export default {
         this.note = data || {};
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.split(this.appName)[0]}${this.appName}/${this.note.id}`;
+        const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
+        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
         window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
         return this.$nextTick();
       }).catch(e => {
@@ -615,7 +617,8 @@ export default {
         this.isDraft = true;
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.split(this.appName)[0]}${this.appName}/${this.note.id}/draft`;
+        const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
+        notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
         window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
         return this.$nextTick();
       }).catch(e => {


### PR DESCRIPTION
ISSUE : after creating a space contains the keyword 'notes' in its name, use the notes application, create some notes => the page's uri wrongly changed when getting note by id or by name and creates a new uri after deleting the keyword 'notes' from the space's name.

FIX : change the way how to change the page's uri, instead of splitting the uri using 'notes' string, get the last index of 'notes' string and do changes from the end of the uri to the last index's value and keep the space's name.