### PR TITLE
TASK-53571: Fix liquibase data initialization due to defaultNullValue default behavior

### DIFF
--- a/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
+++ b/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
@@ -565,6 +565,7 @@
     <addNotNullConstraint
       tableName="WIKI_PAGE_ATTACHMENTS"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 
@@ -573,6 +574,7 @@
     <addNotNullConstraint
       tableName="WIKI_DRAFT_ATTACHMENTS"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 
@@ -581,10 +583,12 @@
     <addNotNullConstraint
       tableName="WIKI_DRAFT_PAGES"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
     <addNotNullConstraint
       tableName="WIKI_DRAFT_PAGES"
       columnName="UPDATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 
@@ -593,10 +597,12 @@
     <addNotNullConstraint
       tableName="WIKI_PAGES"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
     <addNotNullConstraint
       tableName="WIKI_PAGES"
       columnName="UPDATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 
@@ -605,6 +611,7 @@
     <addNotNullConstraint
       tableName="WIKI_PAGE_MOVES"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 
@@ -613,10 +620,12 @@
     <addNotNullConstraint
       tableName="WIKI_PAGE_VERSIONS"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
     <addNotNullConstraint
       tableName="WIKI_PAGE_VERSIONS"
       columnName="UPDATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 
@@ -625,10 +634,12 @@
     <addNotNullConstraint
       tableName="WIKI_TEMPLATES"
       columnName="CREATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
     <addNotNullConstraint
       tableName="WIKI_TEMPLATES"
       columnName="UPDATED_DATE"
+      columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
 


### PR DESCRIPTION
Prior to this fix, when using `defaultNullValue` attribute, Liquibase creates constraints with default value as `String` instead of `TIMESTAMP`.
```bash
2022-01-29 14:00:09,352 | ERROR | Error while applying liquibase changelogs db/changelog/wiki.db.changelog-1.0.0.xml - Cause : Validation Failed:
     11 changes have validation failures
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-47::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-48::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-49::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-49::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-50::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-50::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-51::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-52::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-52::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-53::wiki
          columnDataType is required for addNotNullConstraint on mysql, db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-53::wiki
 [o.e.c.p.impl.LiquibaseDataInitializer<Catalina-utility-3>] 
```
This fix enforces the column datatype to set the correct default value in the case of Nullity.