### PR TITLE
TASK-53835 Fix Search connector labels

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ar.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ar.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} \u0641\u064A {1}
 UIWikiSearchBox.label.Search=\u0628\u062D\u062B
 UIWikiSearchBox.label.SearchFor=\u0627\u0644\u0628\u062D\u062B \u0639\u0646
 UIWikiSearchBox.label.Loading=\u062A\u062D\u0645\u064A\u0644...
-search.connector.label.wiki=\u0627\u0644\u0645\u0644\u0627\u062D\u0638\u0627\u062A
+search.connector.label.notes=\u0627\u0644\u0645\u0644\u0627\u062D\u0638\u0627\u062A
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_aro.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_aro.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} \u0641\u064A {1}
 UIWikiSearchBox.label.Search=\u0627\u0644\u0628\u062D\u062B
 UIWikiSearchBox.label.SearchFor=\u0627\u0644\u0628\u062D\u062B \u0639\u0646
 UIWikiSearchBox.label.Loading=\u062A\u062D\u0645\u064A\u0644...
-search.connector.label.wiki=\u0627\u0644\u0645\u0644\u0627\u062D\u0638\u0627\u062A
+search.connector.label.notes=\u0627\u0644\u0645\u0644\u0627\u062D\u0638\u0627\u062A
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_az.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_az.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Y\u00FCkl\u0259nir...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ca.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ca.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} al {1}
 UIWikiSearchBox.label.Search=Cerca
 UIWikiSearchBox.label.SearchFor=Cerca per
 UIWikiSearchBox.label.Loading=S'est\u00E0 carregant...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ceb.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ceb.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} sa {1}
 UIWikiSearchBox.label.Search=Pagpangita
 UIWikiSearchBox.label.SearchFor=Pagpangita para sa
 UIWikiSearchBox.label.Loading=Nag-load...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_co.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_co.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_cs.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_cs.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} v {1}
 UIWikiSearchBox.label.Search=Hledat
 UIWikiSearchBox.label.SearchFor=Hledat
 UIWikiSearchBox.label.Loading=Na\u010D\u00EDt\u00E1n\u00ED...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_de.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_de.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Suchen
 UIWikiSearchBox.label.SearchFor=Suche nach
 UIWikiSearchBox.label.Loading=Ladevorgang...
-search.connector.label.wiki=Notizen
+search.connector.label.notes=Notizen
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_el.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_el.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} \u03C3\u03C4\u03BF {1}
 UIWikiSearchBox.label.Search=\u0391\u03BD\u03B1\u03B6\u03AE\u03C4\u03B7\u03C3\u03B7
 UIWikiSearchBox.label.SearchFor=\u0391\u03BD\u03B1\u03B6\u03AE\u03C4\u03B7\u03C3\u03B7 \u03B3\u03B9\u03B1
 UIWikiSearchBox.label.Loading=\u03A6\u03CC\u03C1\u03C4\u03C9\u03C3\u03B7...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_es_ES.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_es_ES.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} en {1}
 UIWikiSearchBox.label.Search=B\u00FAsqueda
 UIWikiSearchBox.label.SearchFor=Buscar por
 UIWikiSearchBox.label.Loading=Cargando...
-search.connector.label.wiki=Notas
+search.connector.label.notes=Notas
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_eu.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_eu.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fa.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fa.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} \u062F\u0631 {1}
 UIWikiSearchBox.label.Search=\u062C\u0633\u062A\u062C\u0648
 UIWikiSearchBox.label.SearchFor=\u062C\u0633\u062A\u062C\u0648 \u0628\u0631\u0627\u06CC
 UIWikiSearchBox.label.Loading=\u062F\u0631 \u062D\u0627\u0644 \u0628\u0627\u0631\u06AF\u0630\u0627\u0631\u06CC...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fi.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fil.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fil.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} sa {1}
 UIWikiSearchBox.label.Search=Pagsasaliksik
 UIWikiSearchBox.label.SearchFor=Ang Hanapin para
 UIWikiSearchBox.label.Loading=Nagloload...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} dans {1}
 UIWikiSearchBox.label.Search=Recherche
 UIWikiSearchBox.label.SearchFor=Recherche
 UIWikiSearchBox.label.Loading=Chargement...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hi.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hu.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_hu.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_in.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_in.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} di {1}
 UIWikiSearchBox.label.Search=Cari
 UIWikiSearchBox.label.SearchFor=Mencari
 UIWikiSearchBox.label.Loading=Sedang memuat...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_it.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_it.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}.
 UIWikiSearchBox.label.Search=Cerca
 UIWikiSearchBox.label.SearchFor=Cerca
 UIWikiSearchBox.label.Loading=Caricamento...
-search.connector.label.wiki=Wiki
+search.connector.label.notes=Wiki
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ja.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ja.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={1} \u306B {0} \u304C\u3042\u308A\
 UIWikiSearchBox.label.Search=\u691C\u7D22
 UIWikiSearchBox.label.SearchFor=\u691C\u7D22\u5BFE\u8C61
 UIWikiSearchBox.label.Loading=\u30ED\u30FC\u30C9\u4E2D...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_kab.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_kab.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ko.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ko.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_lt.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_lt.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} i\u0161 {1}
 UIWikiSearchBox.label.Search=Paie\u0161ka
 UIWikiSearchBox.label.SearchFor=Ie\u0161koti
 UIWikiSearchBox.label.Loading=Kraunama...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ms.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ms.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Memuatkan...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_nl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_nl.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Zoeken
 UIWikiSearchBox.label.SearchFor=Zoeken naar
 UIWikiSearchBox.label.Loading=Aan het laden...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_no.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_no.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} i {1}
 UIWikiSearchBox.label.Search=S\u00F8k
 UIWikiSearchBox.label.SearchFor=S\u00F8k etter
 UIWikiSearchBox.label.Loading=Laster inn...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pcm.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pcm.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pl.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} w {1}
 UIWikiSearchBox.label.Search=Szukaj
 UIWikiSearchBox.label.SearchFor=Szukaj
 UIWikiSearchBox.label.Loading=\u0141adowanie...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_BR.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_BR.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} em {1}
 UIWikiSearchBox.label.Search=Buscar
 UIWikiSearchBox.label.SearchFor=Pesquisar por
 UIWikiSearchBox.label.Loading=Carregando...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_PT.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_pt_PT.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} em {1}
 UIWikiSearchBox.label.Search=Pesquisar
 UIWikiSearchBox.label.SearchFor=Pesquisar por
 UIWikiSearchBox.label.Loading=Carregando...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ro.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ro.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} din {1}
 UIWikiSearchBox.label.Search=C\u0103utare
 UIWikiSearchBox.label.SearchFor=C\u0103utare dup\u0103
 UIWikiSearchBox.label.Loading=\u00CEnc\u0103rcare...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ru.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ru.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} \u0432 {1}
 UIWikiSearchBox.label.Search=\u041F\u043E\u0438\u0441\u043A
 UIWikiSearchBox.label.SearchFor=\u0418\u0441\u043A\u0430\u0442\u044C
 UIWikiSearchBox.label.Loading=\u0417\u0430\u0433\u0440\u0443\u0437\u043A\u0430...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sk.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sk.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sl.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} v {1}
 UIWikiSearchBox.label.Search=I\u0161\u010Di
 UIWikiSearchBox.label.SearchFor=I\u0161\u010Di
 UIWikiSearchBox.label.Loading=Nalagam...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sq.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sq.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName=crwdns6789984:0{0}crwdnd6789984:0{
 UIWikiSearchBox.label.Search=crwdns6789985:0crwdne6789985:0
 UIWikiSearchBox.label.SearchFor=crwdns6789986:0crwdne6789986:0
 UIWikiSearchBox.label.Loading=crwdns6789987:0crwdne6789987:0
-search.connector.label.wiki=crwdns6941290:0crwdne6941290:0
+search.connector.label.notes=crwdns6941290:0crwdne6941290:0
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sv_SE.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_sv_SE.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} i {1}
 UIWikiSearchBox.label.Search=S\u00F6k
 UIWikiSearchBox.label.SearchFor=S\u00F6k efter
 UIWikiSearchBox.label.Loading=Laddar...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_th.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_th.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tl.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} sa {1}
 UIWikiSearchBox.label.Search=Paghahanap
 UIWikiSearchBox.label.SearchFor=Paghahanap para sa
 UIWikiSearchBox.label.Loading=Naglo-load...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_tr.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={1} i\u00E7indeki {0}
 UIWikiSearchBox.label.Search=Ara
 UIWikiSearchBox.label.SearchFor=Ara i\u00E7inde
 UIWikiSearchBox.label.Loading=Y\u00FCkleniyor...
-search.connector.label.wiki=Wiki
+search.connector.label.notes=Wiki
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_uk.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_uk.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} \u0443 {1}
 UIWikiSearchBox.label.Search=\u041F\u043E\u0448\u0443\u043A
 UIWikiSearchBox.label.SearchFor=\u0428\u0443\u043A\u0430\u0442\u0438
 UIWikiSearchBox.label.Loading=\u0417\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F...
-search.connector.label.wiki=Wiki
+search.connector.label.notes=Wiki
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ur_IN.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_ur_IN.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=\u062A\u0644\u0627\u0634 \u06A9\u0631\u06CC\u06BA
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=\u0644\u0648\u0688 \u06A9\u0631 \u0631\u06C1\u0627 \u06C1\u06D2...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_vi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_vi.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} trong {1}
 UIWikiSearchBox.label.Search=T\u00ECm ki\u1EBFm
 UIWikiSearchBox.label.SearchFor=T\u00ECm ki\u1EBFm
 UIWikiSearchBox.label.Loading=\u0110ang t\u1EA3i...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_CN.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_CN.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0}\u5728{1}\u4E2D
 UIWikiSearchBox.label.Search=\u641C\u7D22
 UIWikiSearchBox.label.SearchFor=\u641C\u7D22
 UIWikiSearchBox.label.Loading=\u6B63\u5728\u52A0\u8F7D...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_TW.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_zh_TW.properties
@@ -102,7 +102,7 @@ UIWikiPermissionForm.PermissionEntry.fullName={0} in {1}
 UIWikiSearchBox.label.Search=\u641C\u5C0B
 UIWikiSearchBox.label.SearchFor=\u641C\u5C0B
 UIWikiSearchBox.label.Loading=\u6B63\u5728\u8F09\u5165...
-search.connector.label.wiki=Notes
+search.connector.label.notes=Notes
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################


### PR DESCRIPTION
Due to connector name change, the i18N label key of Seach connectors has changed. This modification will ensure to apply the new computed key.