### PR TITLE
Task-50373 : Display order of note tree is not respected

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -967,14 +967,16 @@ public class NotesRestService implements ResourceContainer {
             
             if (!Boolean.TRUE.equals(withDrafts) || Boolean.TRUE.equals(parent.isHasDraftDescendant())) {
               children = parent.getChildren();
+              int indexChild = children.indexOf(bottomChild);
               children.remove(bottomChild);
               
               if (Boolean.TRUE.equals(withDrafts)) {
                 children = children.stream().filter(jsonNodeData -> jsonNodeData.isDraftPage() || Boolean.TRUE.equals(jsonNodeData.isHasDraftDescendant())).collect(Collectors.toList());
               }
               
-            if (!Boolean.TRUE.equals(withDrafts) || bottomChild.isDraftPage() || Boolean.TRUE.equals(bottomChild.isHasDraftDescendant())) {
-                children.add(bottomChild);
+              if (!Boolean.TRUE.equals(withDrafts) || bottomChild.isDraftPage()
+                  || Boolean.TRUE.equals(bottomChild.isHasDraftDescendant())) {
+                children.add(indexChild, bottomChild);
               }
               parent.setChildren(children);
 


### PR DESCRIPTION
Before this fix, when a page display a note tree, in some case, pages are not alphabetically ordered
This problem is due to the calcultation of the tree, which manipulate pages children without keeping the children order
This fix ensure that when we remove an item from a list, we keep the index to be able to readd it at the same place after the calculation