### PR TITLE
Task-51726 : pop up error when editing the home note page

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -539,6 +539,9 @@ public class NotesRestService implements ResourceContainer {
           WikiPageParams noteParams = new WikiPageParams(note_.getWikiType(), note_.getWikiOwner(), newNoteName);
           noteService.removeDraftOfNote(noteParams);
         }
+      } else{
+         //in this case, the note didnt change on title nor content. As we need the page url in front side, we compute it here
+         note_.setUrl(Utils.getPageUrl(note));
       }
       return Response.ok(note_, MediaType.APPLICATION_JSON).cacheControl(cc).build();
     } catch (IllegalAccessException e) {


### PR DESCRIPTION
ISSUES :  when User clicks on the edit button of home page note without any change an error pop-up arises notes.message.Cannot read properties of null (reading 'split') . 
Fix :so the cause of the error is 'spaceDisplayName' in the 'getPathByNoteOwner' method in the 'noteService.js' class then the 'spaceDisplayName' variable receives null because note.url is null . so to receive the correct value of note.url it is necessary to trigger the method 'updateNote' so I added a condition and 'updateNoteById' in the class 'NoteRestService.java'