### PR TITLE
TASK-50564 : paste an image copied to clipboard.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -383,7 +383,7 @@ export default {
             name: this.note.name,
             wikiType: this.note.wikiType,
             wikiOwner: this.note.wikiOwner,
-            content: this.note.content,
+            content: this.getBody() || this.note.content,
             parentPageId: this.note.targetPageId === this.parentPageId ? null : this.parentPageId,
             toBePublished: toPublish,
             appName: this.appName,
@@ -395,7 +395,7 @@ export default {
             name: this.note.name,
             wikiType: this.note.wikiType,
             wikiOwner: this.note.wikiOwner,
-            content: this.note.content,
+            content: this.getBody() || this.note.content,
             parentPageId: this.parentPageId,
             toBePublished: toPublish,
             appName: this.appName,
@@ -444,7 +444,7 @@ export default {
       const draftNote = {
         id: this.note.draftPage ? this.note.id : '',
         title: this.note.title,
-        content: this.note.content,
+        content: this.getBody() || this.note.content,
         name: this.note.name,
         appName: this.appName,
         wikiType: this.note.wikiType,
@@ -461,7 +461,7 @@ export default {
         // if draft page not created persist it only the first time else update it in browser's localStorage
         if (this.note.draftPage && this.note.id) {
           this.note.parentPageId = this.parentPageId;
-          localStorage.setItem(`draftNoteId-${this.note.id}`, JSON.stringify(this.note));
+          localStorage.setItem(`draftNoteId-${this.note.id}`, JSON.stringify(draftNote));
           this.actualNote = {
             name: draftNote.name,
             title: draftNote.title,
@@ -618,6 +618,7 @@ export default {
           },
           change: function (evt) {
             self.note.content = evt.editor.getData();
+            self.autoSave();
             const removeTreeviewBtn =  evt.editor.document.getById( 'remove-treeview' );
             if ( removeTreeviewBtn ) {
               evt.editor.editable().attachListener( removeTreeviewBtn, 'click', function() {
@@ -813,6 +814,10 @@ export default {
       } else {
         return false;
       }
+    },
+    getBody: function() {
+      const newData = CKEDITOR.instances['notesContent'].getData();
+      return newData ? newData : null;
     }
   }
 };


### PR DESCRIPTION
ISSUES : when creating a note that contains a pasted image, the pasted image is not visible also when a draft is saved just after pasting the image then close the editor without saving, then open the saved draft, the draft do not contains the image.
FIX : the first problem is that we cannot read the new content of the ckeditor correctly because the processing of the pasted and downloaded image takes some time and it is solved by adding the getBody() function that reads the content of the ckeditor at the moment the user clicks the save button ,and the second problem is that the localStorage doesn't receive the correct value of the saved draft it is solved by adding the correct value of the new content of the saved draft.