### PR TITLE
TASK-50564 : fix paste an image copied to clipboard.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -209,7 +209,7 @@ export default {
           name: this.notes.name,
           wikiType: this.notes.wikiType,
           wikiOwner: this.notes.wikiOwner,
-          content: this.getBody() || this.note.content,
+          content: this.getBody() || this.notes.content,
           parentPageId: this.notes.parentPageId,
           toBePublished: toPost,
           appName: this.appName,
@@ -335,7 +335,7 @@ export default {
             self.$root.$applicationLoaded();
           },
           change: function (evt) {
-            self.note.content = evt.editor.getData();
+            self.notes.content = evt.editor.getData();
           },
           doubleclick: function(evt) {
             const element = evt.data.element;


### PR DESCRIPTION
ISSUES : when creating a note that contains a pasted image, the pasted image is not visible also when a draft is saved just after pasting the image then close the editor without saving, then open the saved draft, the draft do not contains the image.
FIX : the first problem is that we cannot read the new content of the ckeditor correctly because the processing of the pasted and downloaded image takes some time and it is solved by adding the getBody() function that reads the content of the ckeditor at the moment the user clicks the save button ,and the second problem is that the localStorage doesn't receive the correct value of the saved draft it is solved by adding the correct value of the new content of the saved draft.