### PR TITLE
Task-54548: removed the create and edit buttons for mobile devices #491

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -142,7 +142,7 @@
               contain
               eager />
             <div>
-              <p class="notes-welcome-patragraph">
+              <p v-if="!isMobile" class="notes-welcome-patragraph">
                 <span>{{ $t('notes.label.no-content-no-redactor.content.first') }}</span>
                 <v-tooltip bottom>
                   <template v-slot:activator="{ on, attrs }">


### PR DESCRIPTION
The edit and create page buttons in the note application welcome page should be removed for mobile devices