### PR TITLE
Task-50841: Add access permissions for external users on note editor page. (#454)

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/portal/global/pages.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/portal/global/pages.xml
@@ -24,21 +24,21 @@
   <page>
     <name>notes-editor</name>
     <title>Notes Editor</title>
-    <access-permissions>*:/platform/users</access-permissions>
+    <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
     <container id="top-notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
       <name>top-notes-editor-container</name>
-      <access-permissions>*:/platform/users</access-permissions>
+      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <factory-id>addonContainer</factory-id>
     </container>
     <container id="notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
       <name>notes-editor-container</name>
-      <access-permissions>*:/platform/users</access-permissions>
+      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <factory-id>addonContainer</factory-id>
     </container>
     <container id="bottom-notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
       <name>bottom-notes-editor-container</name>
-      <access-permissions>*:/platform/users</access-permissions>
+      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <factory-id>addonContainer</factory-id>
     </container>
   </page>


### PR DESCRIPTION
(cherry picked from commit 3389c05743b9a6cb0e5c6868f1d8b67440029555)

Issue fixed on 6.3, yet wasn't back-ported on 6.2