### PR TITLE
TASK-55664 Fix JS Error on notes page display

### DIFF
--- a/notes-webapp/webpack.prod.js
+++ b/notes-webapp/webpack.prod.js
@@ -16,6 +16,7 @@ const config = {
     notesSwitch: './src/main/webapp/vue-app/notes-switch/main.js'
   },
   output: {
+    publicPath: '',
     path: path.join(__dirname, 'target/notes/'),
     filename: 'javascript/[name].bundle.js',
     libraryTarget: 'amd'


### PR DESCRIPTION
Prior to this change, when displaying a notes page, an error is displayed . This error is due to recent upgrade to Webpack 5. To fix it, we have to add an option in webpack output .