### PR TITLE
TASK-56675: Deleted notes still accessible by note page links

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
@@ -98,6 +98,7 @@ public class EntityConverter {
       page.setPermissions(convertPermissionEntitiesToPermissionEntries(pageEntity.getPermissions(),
               Arrays.asList(PermissionType.VIEWPAGE, PermissionType.EDITPAGE)));
       page.setActivityId(pageEntity.getActivityId());
+      page.setDeleted(pageEntity.isDeleted());
     }
     return page;
   }

--- a/notes-service/src/main/java/org/exoplatform/wiki/mow/api/Page.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/mow/api/Page.java
@@ -89,6 +89,8 @@ public class Page {
 
   private boolean hasChild;
 
+  private boolean isDeleted;
+
   private Page parent;
 
   private Map<String, List<MetadataItem>> metadatas;

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -176,7 +176,7 @@ public class NotesRestService implements ResourceContainer {
     try {
       Identity identity = ConversationState.getCurrent().getIdentity();
       Page note = noteService.getNoteById(noteId, identity, source);
-      if (note == null) {
+      if (note == null || note.isDeleted()) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
       if (StringUtils.isNotEmpty(noteBookType) && !note.getWikiType().equals(noteBookType)) {

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
@@ -292,6 +292,14 @@ public class TestNoteService extends BaseTest {
 
     assertNotNull(note);
     assertEquals(note.getName(),note1.getName());
+
+    assertFalse(note.isDeleted());
+
+    noteService.deleteNote(note.getWikiType(), note.getWikiOwner(), note.getName());
+    Page deletedNote = noteService.getNoteById(note1.getId(),root,"");
+
+    assertNotNull(deletedNote);
+    assertTrue(deletedNote.isDeleted());
   }
 
   public void testGetNoteOfNoteBookByName() throws WikiException, IllegalAccessException {

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -1,0 +1,97 @@
+package org.exoplatform.wiki.service.rest;
+
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.upload.UploadService;
+import org.exoplatform.wiki.WikiException;
+import org.exoplatform.wiki.mock.MockResourceBundleService;
+import org.exoplatform.wiki.mow.api.Page;
+import org.exoplatform.wiki.service.BreadcrumbData;
+import org.exoplatform.wiki.service.NoteService;
+import org.exoplatform.wiki.service.WikiService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.persistence.EntityNotFoundException;
+import javax.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ConversationState.class })
+public class NotesRestServiceTest {
+
+  @Mock
+  private NoteService      noteService;
+
+  @Mock
+  private WikiService      noteBookService;
+
+  @Mock
+  private UploadService    uploadService;
+
+  private NotesRestService notesRestService;
+
+  @Mock
+  private Identity         identity;
+
+  @Before
+  public void setUp() throws Exception {
+    this.notesRestService = new NotesRestService(noteService, noteBookService, uploadService, new MockResourceBundleService());
+    PowerMockito.mockStatic(ConversationState.class);
+    ConversationState conversationState = mock(ConversationState.class);
+    when(ConversationState.getCurrent()).thenReturn(conversationState);
+    when(ConversationState.getCurrent().getIdentity()).thenReturn(identity);
+  }
+
+  @Test
+  public void getNoteById() throws WikiException, IllegalAccessException {
+    Page page = new Page();
+    List<Page> children = new ArrayList<>();
+    children.add(new Page("child1"));
+    List<BreadcrumbData> breadcrumb = new ArrayList<>();
+    breadcrumb.add(new BreadcrumbData("1", "test", "note", "user"));
+    page.setDeleted(true);
+    when(noteService.getNoteById("1", identity, "source")).thenReturn(null);
+    Response response = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    when(noteService.getNoteById("1", identity, "source")).thenReturn(page);
+    Response response1 = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response1.getStatus());
+    page.setDeleted(false);
+    page.setWikiType("type");
+    Response response2 = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response2.getStatus());
+    page.setWikiType("note");
+    page.setWikiOwner("owner");
+    Response response3 = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response3.getStatus());
+
+    page.setWikiOwner("user");
+    page.setContent("any wiki-children-pages ck-widget any");
+    when(identity.getUserId()).thenReturn("userId");
+    when(noteService.getChildrenNoteOf(page, "userId", false, true)).thenReturn(children);
+
+    when(noteService.getBreadCrumb("note", "user", "1", false)).thenReturn(breadcrumb);
+    when(noteService.updateNote(page)).thenReturn(page);
+    Response response4 = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.OK.getStatusCode(), response4.getStatus());
+
+    doThrow(new IllegalAccessException()).when(noteService).getNoteById("1", identity, "source");
+    Response response5 = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response5.getStatus());
+
+    doThrow(new RuntimeException()).when(noteService).getNoteById("1", identity, "source");
+    Response response6 = notesRestService.getNoteById("1", "note", "user", true, "source");
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response6.getStatus());
+  }
+}


### PR DESCRIPTION
Prior to this change,when deleteing a notes its deleted flag is set to true, while when getting the note by its id not control is added to check if it's deleted or not, and so it's displayed to the user,
This PR should add a check on the dleted flag and return NOT_FOUND http state code if it's deleted