### PR TITLE
Task-54558: Fix edit published note name

### DIFF
--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesExtensions.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesExtensions.js
@@ -19,7 +19,7 @@ export function initNotesExtensions() {
         try {
           const templateParams = activity.templateParams || {};
           if (templateParams.page_type === 'group' && activity.activityStream && activity.activityStream.space) {
-             return `${templateParams.page_url}`;
+            return `${templateParams.page_url}`;
           } else if (templateParams.page_type === 'portal') {
             return `${eXo.env.portal.context}/${templateParams.page_owner}/wiki/${templateParams.page_id}`;
           }

--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesExtensions.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesExtensions.js
@@ -19,12 +19,7 @@ export function initNotesExtensions() {
         try {
           const templateParams = activity.templateParams || {};
           if (templateParams.page_type === 'group' && activity.activityStream && activity.activityStream.space) {
-            const spaceApplications = activity.activityStream.space.dataEntity.applications;
-            const spaceApp = spaceApplications.find(app => app.id === 'WikiPortlet');
-            const spaceAppUri = spaceApp && spaceApp.displayName || 'wiki';
-            const spacePrettyName = activity.activityStream.space.prettyName;
-            const spaceGroupUriPart = templateParams.page_owner.replace(/\//g, ':');
-            return `${eXo.env.portal.context}/g/${spaceGroupUriPart}/${spacePrettyName}/${spaceAppUri}/${templateParams.page_id}`;
+             return `${templateParams.page_url}`;
           } else if (templateParams.page_type === 'portal') {
             return `${eXo.env.portal.context}/${templateParams.page_owner}/wiki/${templateParams.page_id}`;
           }


### PR DESCRIPTION

Prior to this change, when updating the name of  a published note and not publishing it, then preview this note, We could not find this note (path to get a note with the old name)
This PR should make sure to preview any note by getting the note with id and not with name(page_url path note with id).
