### PR TITLE
TASK-56665: Notes drafts cannot be displayed in the notes tree

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -970,12 +970,14 @@ public class NotesRestService implements ResourceContainer {
             
             if (!Boolean.TRUE.equals(withDrafts) || Boolean.TRUE.equals(parent.isHasDraftDescendant())) {
               children = parent.getChildren();
+              if (Boolean.TRUE.equals(withDrafts)) {
+                children = children.stream()
+                                   .filter(jsonNodeData -> jsonNodeData.isDraftPage()
+                                       || Boolean.TRUE.equals(jsonNodeData.isHasDraftDescendant()))
+                                   .collect(Collectors.toList());
+              }
               int indexChild = children.indexOf(bottomChild);
               children.remove(bottomChild);
-              
-              if (Boolean.TRUE.equals(withDrafts)) {
-                children = children.stream().filter(jsonNodeData -> jsonNodeData.isDraftPage() || Boolean.TRUE.equals(jsonNodeData.isHasDraftDescendant())).collect(Collectors.toList());
-              }
               
               if (!Boolean.TRUE.equals(withDrafts) || bottomChild.isDraftPage()
                   || Boolean.TRUE.equals(bottomChild.isHasDraftDescendant())) {

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -1,33 +1,49 @@
 package org.exoplatform.wiki.service.rest;
 
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.rest.impl.EnvironmentContext;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.mock.MockResourceBundleService;
+import org.exoplatform.wiki.mow.api.DraftPage;
 import org.exoplatform.wiki.mow.api.Page;
+import org.exoplatform.wiki.mow.api.Wiki;
 import org.exoplatform.wiki.service.BreadcrumbData;
 import org.exoplatform.wiki.service.NoteService;
+import org.exoplatform.wiki.service.WikiPageParams;
 import org.exoplatform.wiki.service.WikiService;
+import org.exoplatform.wiki.tree.utils.TreeUtils;
+import org.exoplatform.wiki.utils.NoteConstants;
+import org.exoplatform.wiki.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ ConversationState.class })
+@PrepareForTest({ ConversationState.class, EnvironmentContext.class, TreeUtils.class, Utils.class, ExoContainerContext.class,
+    ExoContainer.class })
+@PowerMockIgnore({ "javax.management.*", "jdk.internal.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*",
+        "com.sun.org.apache.*", "org.w3c.*" })
 public class NotesRestServiceTest {
 
   @Mock
@@ -51,6 +67,23 @@ public class NotesRestServiceTest {
     ConversationState conversationState = mock(ConversationState.class);
     when(ConversationState.getCurrent()).thenReturn(conversationState);
     when(ConversationState.getCurrent().getIdentity()).thenReturn(identity);
+
+    PowerMockito.mockStatic(EnvironmentContext.class);
+    EnvironmentContext environmentContext = mock(EnvironmentContext.class);
+    when(EnvironmentContext.getCurrent()).thenReturn(environmentContext);
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getLocale()).thenReturn(new Locale("en"));
+    when(environmentContext.get(HttpServletRequest.class)).thenReturn(request);
+
+    PowerMockito.mockStatic(TreeUtils.class);
+    PowerMockito.mockStatic(Utils.class);
+
+    PowerMockito.mockStatic(ExoContainerContext.class);
+    PowerMockito.mockStatic(ExoContainer.class);
+    ExoContainer exoContainer = mock(ExoContainer.class);
+    when(ExoContainerContext.getCurrentContainer()).thenReturn(exoContainer);
+    when(exoContainer.getComponentInstanceOfType(WikiService.class)).thenReturn(noteBookService);
   }
 
   @Test
@@ -93,5 +126,81 @@ public class NotesRestServiceTest {
     doThrow(new RuntimeException()).when(noteService).getNoteById("1", identity, "source");
     Response response6 = notesRestService.getNoteById("1", "note", "user", true, "source");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response6.getStatus());
+  }
+
+  @Test
+  public void getFullTreeData() throws Exception {
+    Page homePage = new Page("home");
+    homePage.setWikiOwner("user");
+    homePage.setWikiType("WIKIHOME");
+    homePage.setOwner("user");
+    homePage.setId("1");
+    homePage.setParentPageId("0");
+    Wiki noteBook = new Wiki();
+    noteBook.setOwner("user");
+    noteBook.setType("WIKI");
+    noteBook.setId("0");
+    noteBook.setWikiHome(homePage);
+    Page page = new Page("testPage");
+    page.setId("2");
+    page.setParentPageId("1");
+    Page draftPage = new DraftPage();
+    draftPage.setId("3");
+    draftPage.setName("testPageDraft");
+    page.setWikiType("PAGE");
+    draftPage.setParentPageId("1");
+    draftPage.setDraftPage(true);
+    draftPage.setWikiType("PAGE");
+    WikiPageParams pageParams = new WikiPageParams();
+    pageParams.setPageName("home");
+    pageParams.setOwner("user");
+    pageParams.setType("WIKI");
+    List<Page> children = new ArrayList<>(List.of(page, draftPage));
+    homePage.setChildren(children);
+    Deque paramsDeque = mock(Deque.class);
+    when(identity.getUserId()).thenReturn("1");
+    when(TreeUtils.getPageParamsFromPath("path")).thenReturn(pageParams);
+    when(Utils.getStackParams(homePage)).thenReturn(paramsDeque);
+    when(paramsDeque.pop()).thenReturn(pageParams);
+    when(noteService.getNoteOfNoteBookByName(pageParams.getType(),
+                                             pageParams.getOwner(),
+                                             pageParams.getPageName(),
+                                             identity)).thenReturn(null);
+    when(noteService.getNoteOfNoteBookByName(pageParams.getType(),
+                                             pageParams.getOwner(),
+                                             NoteConstants.NOTE_HOME_NAME)).thenReturn(homePage);
+
+    when(noteBookService.getWikiByTypeAndOwner(pageParams.getType(), pageParams.getOwner())).thenReturn(noteBook);
+    when(noteBookService.getWikiByTypeAndOwner(homePage.getWikiType(), homePage.getWikiOwner())).thenReturn(noteBook);
+    doCallRealMethod().when(TreeUtils.class, "getPathFromPageParams", ArgumentMatchers.any());
+    doCallRealMethod().when(Utils.class, "validateWikiOwner", homePage.getWikiType(), homePage.getWikiOwner());
+    doCallRealMethod().when(TreeUtils.class, "tranformToJson", ArgumentMatchers.any(), ArgumentMatchers.any());
+    when(noteBookService.getChildrenPageOf(homePage, ConversationState.getCurrent().getIdentity().getUserId(), true)).thenReturn(children);
+    when(Utils.getObjectFromParams(pageParams)).thenReturn(homePage);
+    when(Utils.isDescendantPage(homePage, page)).thenReturn(true);
+    when(Utils.isDescendantPage(homePage, draftPage)).thenReturn(true);
+
+    Response response = notesRestService.getFullTreeData("path", true);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    Response response3 = notesRestService.getFullTreeData("path", false);
+    assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
+
+
+    doThrow(new IllegalAccessException()).when(noteService)
+                                         .getNoteOfNoteBookByName(pageParams.getType(),
+                                                                  pageParams.getOwner(),
+                                                                  pageParams.getPageName(),
+                                                                  identity);
+    Response response1 = notesRestService.getFullTreeData("path", true);
+    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response1.getStatus());
+
+    doThrow(new RuntimeException()).when(noteService)
+                                   .getNoteOfNoteBookByName(pageParams.getType(),
+                                                            pageParams.getOwner(),
+                                                            pageParams.getPageName(),
+                                                            identity);
+    Response response2 = notesRestService.getFullTreeData("path", true);
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response2.getStatus());
   }
 }


### PR DESCRIPTION
Prior to this change, when selecting drafts filter in notes tree drawer, there was an issue due to an OutOfBoundArrayException because a bad code placement when filter notes children depends on the withDrafts query param, which selecting the child index in the list of children and then filter the list and override its size while keeping and using the old index to insert the draft child in the list
This PR should fix this problem by correctly place the code of fitring the list before selecting the child index to avoid having wrong index and an exception