### PR TITLE
Task-56742: Update Activity content even when not explicitly published

### DIFF
--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -1,33 +1,49 @@
 package org.exoplatform.wiki.service.rest;
 
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.rest.impl.EnvironmentContext;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.mock.MockResourceBundleService;
+import org.exoplatform.wiki.mow.api.DraftPage;
 import org.exoplatform.wiki.mow.api.Page;
+import org.exoplatform.wiki.mow.api.Wiki;
 import org.exoplatform.wiki.service.BreadcrumbData;
 import org.exoplatform.wiki.service.NoteService;
+import org.exoplatform.wiki.service.WikiPageParams;
 import org.exoplatform.wiki.service.WikiService;
+import org.exoplatform.wiki.tree.utils.TreeUtils;
+import org.exoplatform.wiki.utils.NoteConstants;
+import org.exoplatform.wiki.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ ConversationState.class })
+@PrepareForTest({ ConversationState.class, EnvironmentContext.class, TreeUtils.class, Utils.class, ExoContainerContext.class,
+    ExoContainer.class })
+@PowerMockIgnore({ "javax.management.*", "jdk.internal.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*",
+        "com.sun.org.apache.*", "org.w3c.*" })
 public class NotesRestServiceTest {
 
   @Mock
@@ -51,6 +67,23 @@ public class NotesRestServiceTest {
     ConversationState conversationState = mock(ConversationState.class);
     when(ConversationState.getCurrent()).thenReturn(conversationState);
     when(ConversationState.getCurrent().getIdentity()).thenReturn(identity);
+
+    PowerMockito.mockStatic(EnvironmentContext.class);
+    EnvironmentContext environmentContext = mock(EnvironmentContext.class);
+    when(EnvironmentContext.getCurrent()).thenReturn(environmentContext);
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getLocale()).thenReturn(new Locale("en"));
+    when(environmentContext.get(HttpServletRequest.class)).thenReturn(request);
+
+    PowerMockito.mockStatic(TreeUtils.class);
+    PowerMockito.mockStatic(Utils.class);
+
+    PowerMockito.mockStatic(ExoContainerContext.class);
+    PowerMockito.mockStatic(ExoContainer.class);
+    ExoContainer exoContainer = mock(ExoContainer.class);
+    when(ExoContainerContext.getCurrentContainer()).thenReturn(exoContainer);
+    when(exoContainer.getComponentInstanceOfType(WikiService.class)).thenReturn(noteBookService);
   }
 
   @Test
@@ -93,5 +126,81 @@ public class NotesRestServiceTest {
     doThrow(new RuntimeException()).when(noteService).getNoteById("1", identity, "source");
     Response response6 = notesRestService.getNoteById("1", "note", "user", true, "source");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response6.getStatus());
+  }
+
+  @Test
+  public void getFullTreeData() throws Exception {
+    Page homePage = new Page("home");
+    homePage.setWikiOwner("user");
+    homePage.setWikiType("WIKIHOME");
+    homePage.setOwner("user");
+    homePage.setId("1");
+    homePage.setParentPageId("0");
+    Wiki noteBook = new Wiki();
+    noteBook.setOwner("user");
+    noteBook.setType("WIKI");
+    noteBook.setId("0");
+    noteBook.setWikiHome(homePage);
+    Page page = new Page("testPage");
+    page.setId("2");
+    page.setParentPageId("1");
+    Page draftPage = new DraftPage();
+    draftPage.setId("3");
+    draftPage.setName("testPageDraft");
+    page.setWikiType("PAGE");
+    draftPage.setParentPageId("1");
+    draftPage.setDraftPage(true);
+    draftPage.setWikiType("PAGE");
+    WikiPageParams pageParams = new WikiPageParams();
+    pageParams.setPageName("home");
+    pageParams.setOwner("user");
+    pageParams.setType("WIKI");
+    List<Page> children = new ArrayList<>(List.of(page, draftPage));
+    homePage.setChildren(children);
+    Deque paramsDeque = mock(Deque.class);
+    when(identity.getUserId()).thenReturn("1");
+    when(TreeUtils.getPageParamsFromPath("path")).thenReturn(pageParams);
+    when(Utils.getStackParams(homePage)).thenReturn(paramsDeque);
+    when(paramsDeque.pop()).thenReturn(pageParams);
+    when(noteService.getNoteOfNoteBookByName(pageParams.getType(),
+                                             pageParams.getOwner(),
+                                             pageParams.getPageName(),
+                                             identity)).thenReturn(null);
+    when(noteService.getNoteOfNoteBookByName(pageParams.getType(),
+                                             pageParams.getOwner(),
+                                             NoteConstants.NOTE_HOME_NAME)).thenReturn(homePage);
+
+    when(noteBookService.getWikiByTypeAndOwner(pageParams.getType(), pageParams.getOwner())).thenReturn(noteBook);
+    when(noteBookService.getWikiByTypeAndOwner(homePage.getWikiType(), homePage.getWikiOwner())).thenReturn(noteBook);
+    doCallRealMethod().when(TreeUtils.class, "getPathFromPageParams", ArgumentMatchers.any());
+    doCallRealMethod().when(Utils.class, "validateWikiOwner", homePage.getWikiType(), homePage.getWikiOwner());
+    doCallRealMethod().when(TreeUtils.class, "tranformToJson", ArgumentMatchers.any(), ArgumentMatchers.any());
+    when(noteBookService.getChildrenPageOf(homePage, ConversationState.getCurrent().getIdentity().getUserId(), true)).thenReturn(children);
+    when(Utils.getObjectFromParams(pageParams)).thenReturn(homePage);
+    when(Utils.isDescendantPage(homePage, page)).thenReturn(true);
+    when(Utils.isDescendantPage(homePage, draftPage)).thenReturn(true);
+
+    Response response = notesRestService.getFullTreeData("path", true);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+    Response response3 = notesRestService.getFullTreeData("path", false);
+    assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
+
+
+    doThrow(new IllegalAccessException()).when(noteService)
+                                         .getNoteOfNoteBookByName(pageParams.getType(),
+                                                                  pageParams.getOwner(),
+                                                                  pageParams.getPageName(),
+                                                                  identity);
+    Response response1 = notesRestService.getFullTreeData("path", true);
+    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response1.getStatus());
+
+    doThrow(new RuntimeException()).when(noteService)
+                                   .getNoteOfNoteBookByName(pageParams.getType(),
+                                                            pageParams.getOwner(),
+                                                            pageParams.getPageName(),
+                                                            identity);
+    Response response2 = notesRestService.getFullTreeData("path", true);
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response2.getStatus());
   }
 }

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -1,49 +1,33 @@
 package org.exoplatform.wiki.service.rest;
 
-import org.exoplatform.container.ExoContainer;
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.services.rest.impl.EnvironmentContext;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.mock.MockResourceBundleService;
-import org.exoplatform.wiki.mow.api.DraftPage;
 import org.exoplatform.wiki.mow.api.Page;
-import org.exoplatform.wiki.mow.api.Wiki;
 import org.exoplatform.wiki.service.BreadcrumbData;
 import org.exoplatform.wiki.service.NoteService;
-import org.exoplatform.wiki.service.WikiPageParams;
 import org.exoplatform.wiki.service.WikiService;
-import org.exoplatform.wiki.tree.utils.TreeUtils;
-import org.exoplatform.wiki.utils.NoteConstants;
-import org.exoplatform.wiki.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.persistence.EntityNotFoundException;
 import javax.ws.rs.core.Response;
 
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
-import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ ConversationState.class, EnvironmentContext.class, TreeUtils.class, Utils.class, ExoContainerContext.class,
-    ExoContainer.class })
-@PowerMockIgnore({ "javax.management.*", "jdk.internal.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*",
-        "com.sun.org.apache.*", "org.w3c.*" })
+@PrepareForTest({ ConversationState.class })
 public class NotesRestServiceTest {
 
   @Mock
@@ -67,23 +51,6 @@ public class NotesRestServiceTest {
     ConversationState conversationState = mock(ConversationState.class);
     when(ConversationState.getCurrent()).thenReturn(conversationState);
     when(ConversationState.getCurrent().getIdentity()).thenReturn(identity);
-
-    PowerMockito.mockStatic(EnvironmentContext.class);
-    EnvironmentContext environmentContext = mock(EnvironmentContext.class);
-    when(EnvironmentContext.getCurrent()).thenReturn(environmentContext);
-
-    HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getLocale()).thenReturn(new Locale("en"));
-    when(environmentContext.get(HttpServletRequest.class)).thenReturn(request);
-
-    PowerMockito.mockStatic(TreeUtils.class);
-    PowerMockito.mockStatic(Utils.class);
-
-    PowerMockito.mockStatic(ExoContainerContext.class);
-    PowerMockito.mockStatic(ExoContainer.class);
-    ExoContainer exoContainer = mock(ExoContainer.class);
-    when(ExoContainerContext.getCurrentContainer()).thenReturn(exoContainer);
-    when(exoContainer.getComponentInstanceOfType(WikiService.class)).thenReturn(noteBookService);
   }
 
   @Test
@@ -126,81 +93,5 @@ public class NotesRestServiceTest {
     doThrow(new RuntimeException()).when(noteService).getNoteById("1", identity, "source");
     Response response6 = notesRestService.getNoteById("1", "note", "user", true, "source");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response6.getStatus());
-  }
-
-  @Test
-  public void getFullTreeData() throws Exception {
-    Page homePage = new Page("home");
-    homePage.setWikiOwner("user");
-    homePage.setWikiType("WIKIHOME");
-    homePage.setOwner("user");
-    homePage.setId("1");
-    homePage.setParentPageId("0");
-    Wiki noteBook = new Wiki();
-    noteBook.setOwner("user");
-    noteBook.setType("WIKI");
-    noteBook.setId("0");
-    noteBook.setWikiHome(homePage);
-    Page page = new Page("testPage");
-    page.setId("2");
-    page.setParentPageId("1");
-    Page draftPage = new DraftPage();
-    draftPage.setId("3");
-    draftPage.setName("testPageDraft");
-    page.setWikiType("PAGE");
-    draftPage.setParentPageId("1");
-    draftPage.setDraftPage(true);
-    draftPage.setWikiType("PAGE");
-    WikiPageParams pageParams = new WikiPageParams();
-    pageParams.setPageName("home");
-    pageParams.setOwner("user");
-    pageParams.setType("WIKI");
-    List<Page> children = new ArrayList<>(List.of(page, draftPage));
-    homePage.setChildren(children);
-    Deque paramsDeque = mock(Deque.class);
-    when(identity.getUserId()).thenReturn("1");
-    when(TreeUtils.getPageParamsFromPath("path")).thenReturn(pageParams);
-    when(Utils.getStackParams(homePage)).thenReturn(paramsDeque);
-    when(paramsDeque.pop()).thenReturn(pageParams);
-    when(noteService.getNoteOfNoteBookByName(pageParams.getType(),
-                                             pageParams.getOwner(),
-                                             pageParams.getPageName(),
-                                             identity)).thenReturn(null);
-    when(noteService.getNoteOfNoteBookByName(pageParams.getType(),
-                                             pageParams.getOwner(),
-                                             NoteConstants.NOTE_HOME_NAME)).thenReturn(homePage);
-
-    when(noteBookService.getWikiByTypeAndOwner(pageParams.getType(), pageParams.getOwner())).thenReturn(noteBook);
-    when(noteBookService.getWikiByTypeAndOwner(homePage.getWikiType(), homePage.getWikiOwner())).thenReturn(noteBook);
-    doCallRealMethod().when(TreeUtils.class, "getPathFromPageParams", ArgumentMatchers.any());
-    doCallRealMethod().when(Utils.class, "validateWikiOwner", homePage.getWikiType(), homePage.getWikiOwner());
-    doCallRealMethod().when(TreeUtils.class, "tranformToJson", ArgumentMatchers.any(), ArgumentMatchers.any());
-    when(noteBookService.getChildrenPageOf(homePage, ConversationState.getCurrent().getIdentity().getUserId(), true)).thenReturn(children);
-    when(Utils.getObjectFromParams(pageParams)).thenReturn(homePage);
-    when(Utils.isDescendantPage(homePage, page)).thenReturn(true);
-    when(Utils.isDescendantPage(homePage, draftPage)).thenReturn(true);
-
-    Response response = notesRestService.getFullTreeData("path", true);
-    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-
-    Response response3 = notesRestService.getFullTreeData("path", false);
-    assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
-
-
-    doThrow(new IllegalAccessException()).when(noteService)
-                                         .getNoteOfNoteBookByName(pageParams.getType(),
-                                                                  pageParams.getOwner(),
-                                                                  pageParams.getPageName(),
-                                                                  identity);
-    Response response1 = notesRestService.getFullTreeData("path", true);
-    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response1.getStatus());
-
-    doThrow(new RuntimeException()).when(noteService)
-                                   .getNoteOfNoteBookByName(pageParams.getType(),
-                                                            pageParams.getOwner(),
-                                                            pageParams.getPageName(),
-                                                            identity);
-    Response response2 = notesRestService.getFullTreeData("path", true);
-    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response2.getStatus());
   }
 }

--- a/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -103,6 +103,10 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
       isNewActivity = (activity == null);
     }
 
+    if (isNewActivity && !page.isToBePublished()) {
+      return null;
+    }
+
     if (isNewActivity) {
       if (page.isMinorEdit()) {
         return null;
@@ -155,8 +159,10 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
       if (PageUpdateType.MOVE_PAGE.equals(activityType)) {
         activity.setStreamOwner(ownerStream.getRemoteId());
       }
-      activity.setUpdated(new Date().getTime());
-      activityManager.updateActivity(activity);
+      if (page.isToBePublished()) {
+        activity.setUpdated(new Date().getTime());
+      }
+      activityManager.updateActivity(activity, page.isToBePublished());
     }
     return activity;
   }
@@ -237,15 +243,6 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
                               String pageId,
                               Page page,
                               PageUpdateType activityType) throws WikiException {
-    try {
-      Class.forName("org.exoplatform.social.core.space.spi.SpaceService");
-    } catch (ClassNotFoundException e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("eXo Social components not found!", e);
-      }
-      return;
-    }
-
     // Not raise the activity in case of user space
     if (PortalConfig.USER_TYPE.equals(wikiType)) {
       return;
@@ -346,7 +343,7 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
                              Page page,
                              PageUpdateType wikiUpdateType) throws WikiException {
     // Generate an activity only in the following cases
-    if (page != null && wikiUpdateType != null && page.isToBePublished()) {
+    if (page != null && wikiUpdateType != null) {
       saveActivity(wikiType, wikiOwner, pageId, page, wikiUpdateType);
     }
   }

--- a/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -9,7 +9,9 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.service.PageUpdateType;
 import org.exoplatform.wiki.service.WikiService;
+import org.exoplatform.wiki.utils.NoteConstants;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -36,13 +38,17 @@ public class WikiSpaceActivityPublisherTest {
   @Mock
   private SpaceService     spaceService;
 
+  @Mock
+  private NoteConstants noteConstants ;
+
+
   @Test
   public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
     // Given
     WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
                                                                                            identityManager,
                                                                                            activityManager,
-                                                                                           spaceService);
+            spaceService);
     WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
     Page page = new Page();
 
@@ -54,20 +60,52 @@ public class WikiSpaceActivityPublisherTest {
   }
 
   @Test
-  public void shouldNotCreateActivityWhenUpdateTypeIsPermissionsChange() throws Exception {
+  public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
     // Given
     WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
                                                                                            identityManager,
                                                                                            activityManager,
                                                                                            spaceService);
     WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-    Page page = new Page();
+
+
+    Page page1 = new Page();
 
     // When
-    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null,  PageUpdateType.EDIT_PAGE_PERMISSIONS);
 
     // Then
-    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page, null);
+    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page1, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+  }
+
+
+  @Test
+  public void  shouldNotDeleteActivityWhenActivityIdIsEmpty()throws Exception{
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+            identityManager,
+            activityManager,
+            spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page2 = new Page();
+    page2.setActivityId("");
+    //when
+    wikiSpaceActivityPublisher.postDeletePage( "wikiType", "wikiOwner", "pageId", page2);
+    //then
+    verify(activityManager, never()).deleteActivity(page2.getActivityId());
+  }
+  @Test
+  public void  shouldDeleteActivityWhenActivityIdIsNotEmpty()throws Exception{
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+            identityManager,
+            activityManager,
+            spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page2 = new Page();
+    page2.setActivityId("activityId");
+    //when
+    wikiSpaceActivityPublisher.postDeletePage( "wikiType", "wikiOwner", "pageId", page2);
+    //then
+    verify(activityManager, times(1)).deleteActivity(page2.getActivityId());
   }
 
 }

--- a/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -30,158 +30,172 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class WikiSpaceActivityPublisherTest {
 
-    @Mock
-    private WikiService wikiService;
+  @Mock
+  private WikiService wikiService;
 
-    @Mock
-    private IdentityManager identityManager;
+  @Mock
+  private IdentityManager identityManager;
 
-    @Mock
-    private ActivityManager activityManager;
+  @Mock
+  private ActivityManager activityManager;
 
-    @Mock
-    private SpaceService spaceService;
+  @Mock
+  private SpaceService spaceService;
 
-    @Mock
-    private ConversationState conversationState;
+  @Mock
+  private ConversationState conversationState;
 
-    @Test
-    public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
-        // Given
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                identityManager,
-                activityManager,
-                spaceService);
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-        Page page = new Page();
+  @Test
+  public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
+    // Given
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+                                                                                           identityManager,
+                                                                                           activityManager,
+                                                                                           spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
 
-        // When
-        wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, null);
+    // When
+    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, null);
 
-        // Then
-        verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page, null);
-    }
+    // Then
+    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page, null);
+  }
 
-    @Test
-    public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
-        // Given
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                identityManager,
-                activityManager,
-                spaceService);
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-        // When
-        wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-        // Then
-        verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-    }
+  @Test
+  public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
+    // Given
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+                                                                                           identityManager,
+                                                                                           activityManager,
+                                                                                           spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    // When
+    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    // Then
+    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal",
+                                                                "portal1",
+                                                                "page1",
+                                                                null,
+                                                                PageUpdateType.EDIT_PAGE_PERMISSIONS);
+  }
 
-    @Test
-    //fail to generate new activity when is not to be published
-    public void sholNotgenerateActivityWhenIsNotToBpublished() throws Exception {
+  @Test
+  //fail to generate new activity when is not to be published
+  public void sholNotgenerateActivityWhenIsNotToBpublished() throws Exception {
 
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
-                wikiService,
-                identityManager,
-                activityManager,
-                spaceService);
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-        Page page = new Page();
-        page.setCanView(true);
-        page.setToBePublished(false);
-        Identity identity = new Identity("user");
-        ConversationState conversationState = new ConversationState(identity);
-        ConversationState.setCurrent(conversationState);
-        Space space = new Space();
-        space.setPrettyName("user");
-        org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
-        when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
-        when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
-        when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
-        // When
-        wikiSpaceActivityPublisherSpy.saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-        // Then
-        //verify not  saveActivity
-        verify(activityManager, never()).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
-        identity = null;
-        identity1 = null;
-        page = null;
-        space = null;
-        conversationState = null;
-    }
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+    page.setCanView(true);
+    page.setToBePublished(false);
+    Identity identity = new Identity("user");
+    ConversationState conversationState = new ConversationState(identity);
+    ConversationState.setCurrent(conversationState);
+    Space space = new Space();
+    space.setPrettyName("user");
+    org.exoplatform.social.core.identity.model.Identity
+        identity1 =
+        new org.exoplatform.social.core.identity.model.Identity("user");
+    when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+    // When
+    wikiSpaceActivityPublisherSpy.saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    // Then
+    //verify not  saveActivity
+    verify(activityManager, never()).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
+    identity = null;
+    identity1 = null;
+    page = null;
+    space = null;
+    conversationState = null;
+  }
 
-    @Test
-    //Generate new activity when is to be published
-    public void sholdGenerateNewActivityWhenIsToBublished() throws Exception {
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
-                wikiService,
-                identityManager,
-                activityManager,
-                spaceService);
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-        Page page = new Page();
-        page.setCanView(true);
-        page.setToBePublished(true);
-        Identity identity = new Identity("user");
-        ConversationState conversationState = new ConversationState(identity);
-        ConversationState.setCurrent(conversationState);
-        Space space = new Space();
-        space.setPrettyName("user");
-        org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
-        when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
-        when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
-        when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
-        // When
-        wikiSpaceActivityPublisherSpy.saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-        //then
-        //verify save new Activity
-        verify(activityManager, times(1)).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
-        identity = null;
-        identity1 = null;
-        page = null;
-        space = null;
-        conversationState = null;
-    }
+  @Test
+  //Generate new activity when is to be published
+  public void sholdGenerateNewActivityWhenIsToBublished() throws Exception {
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+    page.setCanView(true);
+    page.setToBePublished(true);
+    Identity identity = new Identity("user");
+    ConversationState conversationState = new ConversationState(identity);
+    ConversationState.setCurrent(conversationState);
+    Space space = new Space();
+    space.setPrettyName("user");
+    org.exoplatform.social.core.identity.model.Identity
+        identity1 =
+        new org.exoplatform.social.core.identity.model.Identity("user");
+    when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+    // When
+    wikiSpaceActivityPublisherSpy.saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    //then
+    //verify save new Activity
+    verify(activityManager, times(1)).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
+    identity = null;
+    identity1 = null;
+    page = null;
+    space = null;
+    conversationState = null;
+  }
 
-    @Test
-    //update activity when Is not new activity and not to be published
-    public void sholdupdateActivityWhenIsNotNewAndNotToBublished() throws Exception {
-        // Given
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
-                wikiService,
-                identityManager,
-                activityManager,
-                spaceService);
-        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-        Page page = new Page();
-        page.setCanView(true);
-        page.setToBePublished(false);
-        page.setActivityId("notNull");
-        ExoSocialActivityImpl activity = new ExoSocialActivityImpl();
-        activity.setId(page.getId());
-        Identity identity = new Identity("user");
-        ConversationState conversationState = new ConversationState(identity);
-        ConversationState.setCurrent(conversationState);
-        Space space = new Space();
-        space.setPrettyName("user");
-        org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
-        when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
-        when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
-        when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
-        when(activityManager.getActivity(page.getActivityId())).thenReturn(activity);
-        // When
-        wikiSpaceActivityPublisherSpy.postUpdatePage("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-        // Then
-        //verify call methode saveActivity
-        verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-        //verify update activity
-        verify(activityManager, times(1)).updateActivity(activity, page.isToBePublished());
-        identity = null;
-        identity1 = null;
-        page = null;
-        activity = null;
-        space = null;
-        conversationState = null;
-    }
+  @Test
+  //update activity when Is not new activity and not to be published
+  public void sholdupdateActivityWhenIsNotNewAndNotToBublished() throws Exception {
+    // Given
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+    page.setCanView(true);
+    page.setToBePublished(false);
+    page.setActivityId("notNull");
+    ExoSocialActivityImpl activity = new ExoSocialActivityImpl();
+    activity.setId(page.getId());
+    Identity identity = new Identity("user");
+    ConversationState conversationState = new ConversationState(identity);
+    ConversationState.setCurrent(conversationState);
+    Space space = new Space();
+    space.setPrettyName("user");
+    org.exoplatform.social.core.identity.model.Identity
+        identity1 =
+        new org.exoplatform.social.core.identity.model.Identity("user");
+    when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+    when(activityManager.getActivity(page.getActivityId())).thenReturn(activity);
+    // When
+    wikiSpaceActivityPublisherSpy.postUpdatePage("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    // Then
+    //verify call methode saveActivity
+    verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group",
+                                                                 "portal1",
+                                                                 "page1",
+                                                                 page,
+                                                                 PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    //verify update activity
+    verify(activityManager, times(1)).updateActivity(activity, page.isToBePublished());
+    identity = null;
+    identity1 = null;
+    page = null;
+    activity = null;
+    space = null;
+    conversationState = null;
+  }
 
 }

--- a/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -3,8 +3,10 @@ package org.exoplatform.wiki.ext.impl;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.service.PageUpdateType;
@@ -18,6 +20,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -26,86 +30,158 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class WikiSpaceActivityPublisherTest {
 
-  @Mock
-  private WikiService      wikiService;
+    @Mock
+    private WikiService wikiService;
 
-  @Mock
-  private IdentityManager  identityManager;
+    @Mock
+    private IdentityManager identityManager;
 
-  @Mock
-  private ActivityManager  activityManager;
+    @Mock
+    private ActivityManager activityManager;
 
-  @Mock
-  private SpaceService     spaceService;
+    @Mock
+    private SpaceService spaceService;
 
-  @Mock
-  private NoteConstants noteConstants ;
+    @Mock
+    private ConversationState conversationState;
 
+    @Test
+    public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
+        // Given
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+                identityManager,
+                activityManager,
+                spaceService);
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+        Page page = new Page();
 
-  @Test
-  public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
-    // Given
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                                                                                           identityManager,
-                                                                                           activityManager,
-            spaceService);
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-    Page page = new Page();
+        // When
+        wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, null);
 
-    // When
-    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, null);
+        // Then
+        verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page, null);
+    }
 
-    // Then
-    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page, null);
-  }
+    @Test
+    public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
+        // Given
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
+                identityManager,
+                activityManager,
+                spaceService);
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+        // When
+        wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+        // Then
+        verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    }
 
-  @Test
-  public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
-    // Given
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                                                                                           identityManager,
-                                                                                           activityManager,
-                                                                                           spaceService);
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    @Test
+    //fail to generate new activity when is not to be published
+    public void sholNotgenerateActivityWhenIsNotToBpublished() throws Exception {
 
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+                wikiService,
+                identityManager,
+                activityManager,
+                spaceService);
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+        Page page = new Page();
+        page.setCanView(true);
+        page.setToBePublished(false);
+        Identity identity = new Identity("user");
+        ConversationState conversationState = new ConversationState(identity);
+        ConversationState.setCurrent(conversationState);
+        Space space = new Space();
+        space.setPrettyName("user");
+        org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
+        when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+        when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+        when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+        // When
+        wikiSpaceActivityPublisherSpy.saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+        // Then
+        //verify not  saveActivity
+        verify(activityManager, never()).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
+        identity = null;
+        identity1 = null;
+        page = null;
+        space = null;
+        conversationState = null;
+    }
 
-    Page page1 = new Page();
+    @Test
+    //Generate new activity when is to be published
+    public void sholdGenerateNewActivityWhenIsToBublished() throws Exception {
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+                wikiService,
+                identityManager,
+                activityManager,
+                spaceService);
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+        Page page = new Page();
+        page.setCanView(true);
+        page.setToBePublished(true);
+        Identity identity = new Identity("user");
+        ConversationState conversationState = new ConversationState(identity);
+        ConversationState.setCurrent(conversationState);
+        Space space = new Space();
+        space.setPrettyName("user");
+        org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
+        when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+        when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+        when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+        // When
+        wikiSpaceActivityPublisherSpy.saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+        //then
+        //verify save new Activity
+        verify(activityManager, times(1)).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
+        identity = null;
+        identity1 = null;
+        page = null;
+        space = null;
+        conversationState = null;
+    }
 
-    // When
-    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null,  PageUpdateType.EDIT_PAGE_PERMISSIONS);
-
-    // Then
-    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page1, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-  }
-
-
-  @Test
-  public void  shouldNotDeleteActivityWhenActivityIdIsEmpty()throws Exception{
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-            identityManager,
-            activityManager,
-            spaceService);
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-    Page page2 = new Page();
-    page2.setActivityId("");
-    //when
-    wikiSpaceActivityPublisher.postDeletePage( "wikiType", "wikiOwner", "pageId", page2);
-    //then
-    verify(activityManager, never()).deleteActivity(page2.getActivityId());
-  }
-  @Test
-  public void  shouldDeleteActivityWhenActivityIdIsNotEmpty()throws Exception{
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-            identityManager,
-            activityManager,
-            spaceService);
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
-    Page page2 = new Page();
-    page2.setActivityId("activityId");
-    //when
-    wikiSpaceActivityPublisher.postDeletePage( "wikiType", "wikiOwner", "pageId", page2);
-    //then
-    verify(activityManager, times(1)).deleteActivity(page2.getActivityId());
-  }
+    @Test
+    //update activity when Is not new activity and not to be published
+    public void sholdupdateActivityWhenIsNotNewAndNotToBublished() throws Exception {
+        // Given
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+                wikiService,
+                identityManager,
+                activityManager,
+                spaceService);
+        WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+        Page page = new Page();
+        page.setCanView(true);
+        page.setToBePublished(false);
+        page.setActivityId("notNull");
+        ExoSocialActivityImpl activity = new ExoSocialActivityImpl();
+        activity.setId(page.getId());
+        Identity identity = new Identity("user");
+        ConversationState conversationState = new ConversationState(identity);
+        ConversationState.setCurrent(conversationState);
+        Space space = new Space();
+        space.setPrettyName("user");
+        org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
+        when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+        when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+        when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+        when(activityManager.getActivity(page.getActivityId())).thenReturn(activity);
+        // When
+        wikiSpaceActivityPublisherSpy.postUpdatePage("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+        // Then
+        //verify call methode saveActivity
+        verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+        //verify update activity
+        verify(activityManager, times(1)).updateActivity(activity, page.isToBePublished());
+        identity = null;
+        identity1 = null;
+        page = null;
+        activity = null;
+        space = null;
+        conversationState = null;
+    }
 
 }

--- a/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -61,7 +61,7 @@ public class WikiSpaceActivityPublisherTest {
   }
 
   @Test
-  public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
+  public void shouldNotCreateActivityWhenPageIsNull() throws Exception {
     // Given
     WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
          wikiService,

--- a/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -45,10 +45,11 @@ public class WikiSpaceActivityPublisherTest {
   @Test
   public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
     // Given
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                                                                                           identityManager,
-                                                                                           activityManager,
-                                                                                           spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
     WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
     Page page = new Page();
 
@@ -62,19 +63,16 @@ public class WikiSpaceActivityPublisherTest {
   @Test
   public void shouldNotCreateActivityWhenPageIsnull() throws Exception {
     // Given
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                                                                                           identityManager,
-                                                                                           activityManager,
-                                                                                           spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+         wikiService,
+         identityManager,
+         activityManager,
+         spaceService);
     WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
     // When
     wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
     // Then
-    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal",
-                                                                "portal1",
-                                                                "page1",
-                                                                null,
-                                                                PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
   }
 
   @Test
@@ -135,7 +133,6 @@ public class WikiSpaceActivityPublisherTest {
   }
 
   @Test
-  //update activity when Is not new activity and not to be published
   public void shouldUpdateActivityWhenIsNotNewAndNotToBePublished() throws Exception {
     // Given
     WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
@@ -168,6 +165,7 @@ public class WikiSpaceActivityPublisherTest {
     //verify call method saveActivity
     verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
     //verify update activity
+    verify(activityManager, times(1)).updateActivity(activity, page.isToBePublished());
   }
 
 }


### PR DESCRIPTION
ISSUE : when saving & posting a note then get back to update the old title and content are displayed (the note activity not updated)
Fix :Update Activity content even when not explicitly published