### PR TITLE
Task-56834: Can't add a text after deleting automatic children image (#512)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -80,7 +80,7 @@
               :placeholder="notesBodyPlaceholder"
               class="notesFormInput"
               name="notesContent">
-                     </textarea>
+            </textarea>
           </div>
         </div>
       </form>
@@ -603,11 +603,7 @@ export default {
               evt.editor.editable().attachListener( removeTreeviewBtn, 'click', function() {
                 const treeviewParentWrapper = evt.editor.document.getById( 'note-children-container' );
                 if ( treeviewParentWrapper) {
-                  const newLine = treeviewParentWrapper.getNext();
                   treeviewParentWrapper.remove();
-                  if ( newLine.$.innerText.trim().length === 0) {
-                    newLine.remove();
-                  }
                   self.note.content = evt.editor.getData();
                 }
                 self.setFocus();


### PR DESCRIPTION
Prior to this change, when create a space then navigate to Notes , add notes with Title 'Notes1' and then add sub notes with Title 'test1.1' so click in edit via icon , when i delete note-children-container by icon remove-treeview .
This is due to changing,I can't add a text after deleting automatic children image ,
After this change, we ensure that when delete a children container note in the body , i can add a text after deleting.