### PR TITLE
Task-56742: Update Activity content even when not explicitly publishe…

### DIFF
--- a/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -103,6 +103,10 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
       isNewActivity = (activity == null);
     }
 
+    if (isNewActivity && !page.isToBePublished()) {
+      return null;
+    }
+
     if (isNewActivity) {
       if (page.isMinorEdit()) {
         return null;
@@ -155,8 +159,10 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
       if (PageUpdateType.MOVE_PAGE.equals(activityType)) {
         activity.setStreamOwner(ownerStream.getRemoteId());
       }
-      activity.setUpdated(new Date().getTime());
-      activityManager.updateActivity(activity);
+      if (page.isToBePublished()) {
+        activity.setUpdated(new Date().getTime());
+      }
+      activityManager.updateActivity(activity, page.isToBePublished());
     }
     return activity;
   }
@@ -237,15 +243,6 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
                               String pageId,
                               Page page,
                               PageUpdateType activityType) throws WikiException {
-    try {
-      Class.forName("org.exoplatform.social.core.space.spi.SpaceService");
-    } catch (ClassNotFoundException e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("eXo Social components not found!", e);
-      }
-      return;
-    }
-
     // Not raise the activity in case of user space
     if (PortalConfig.USER_TYPE.equals(wikiType)) {
       return;
@@ -346,7 +343,7 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
                              Page page,
                              PageUpdateType wikiUpdateType) throws WikiException {
     // Generate an activity only in the following cases
-    if (page != null && wikiUpdateType != null && page.isToBePublished()) {
+    if (page != null && wikiUpdateType != null) {
       saveActivity(wikiType, wikiOwner, pageId, page, wikiUpdateType);
     }
   }

--- a/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/notes-social-integration/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -3,19 +3,25 @@ package org.exoplatform.wiki.ext.impl;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.service.PageUpdateType;
 import org.exoplatform.wiki.service.WikiService;
+import org.exoplatform.wiki.utils.NoteConstants;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -25,24 +31,25 @@ import static org.mockito.Mockito.*;
 public class WikiSpaceActivityPublisherTest {
 
   @Mock
-  private WikiService      wikiService;
+  private WikiService     wikiService;
 
   @Mock
-  private IdentityManager  identityManager;
+  private IdentityManager identityManager;
 
   @Mock
-  private ActivityManager  activityManager;
+  private ActivityManager activityManager;
 
   @Mock
-  private SpaceService     spaceService;
+  private SpaceService    spaceService;
 
   @Test
   public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
     // Given
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                                                                                           identityManager,
-                                                                                           activityManager,
-                                                                                           spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
     WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
     Page page = new Page();
 
@@ -54,20 +61,111 @@ public class WikiSpaceActivityPublisherTest {
   }
 
   @Test
-  public void shouldNotCreateActivityWhenUpdateTypeIsPermissionsChange() throws Exception {
+  public void shouldNotCreateActivityWhenPageIsNull() throws Exception {
     // Given
-    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService,
-                                                                                           identityManager,
-                                                                                           activityManager,
-                                                                                           spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+         wikiService,
+         identityManager,
+         activityManager,
+         spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    // When
+    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    // Then
+    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", null, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+  }
+
+  @Test
+  public void shouldNotGenerateActivityWhenIsNotToBePublished() throws Exception {
+
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
     WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
     Page page = new Page();
-
+    page.setCanView(true);
+    page.setToBePublished(false);
+    Identity identity = new Identity("user");
+    ConversationState conversationState = new ConversationState(identity);
+    ConversationState.setCurrent(conversationState);
+    Space space = new Space();
+    space.setPrettyName("user");
+    org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
+    when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
     // When
-    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
-
+    wikiSpaceActivityPublisherSpy.postUpdatePage("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
     // Then
-    verify(wikiSpaceActivityPublisherSpy, never()).saveActivity("portal", "portal1", "page1", page, null);
+    //verify not  saveActivity
+    verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    verify(activityManager, never()).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
+  }
+
+  @Test
+  public void shouldGenerateNewActivityWhenIsToBePublished() throws Exception {
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+    page.setCanView(true);
+    page.setToBePublished(true);
+    Identity identity = new Identity("user");
+    ConversationState conversationState = new ConversationState(identity);
+    ConversationState.setCurrent(conversationState);
+    Space space = new Space();
+    space.setPrettyName("user");
+    org.exoplatform.social.core.identity.model.Identity identity1 = new org.exoplatform.social.core.identity.model.Identity("user");
+    when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+    // When
+    wikiSpaceActivityPublisherSpy.postUpdatePage("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    //then
+    //verify save new Activity
+    verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    verify(activityManager, times(1)).saveActivityNoReturn(identity1, new ExoSocialActivityImpl());
+  }
+
+  @Test
+  public void shouldUpdateActivityWhenIsNotNewAndNotToBePublished() throws Exception {
+    // Given
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(
+        wikiService,
+        identityManager,
+        activityManager,
+        spaceService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+    page.setCanView(true);
+    page.setToBePublished(false);
+    page.setActivityId("notNull");
+    ExoSocialActivityImpl activity = new ExoSocialActivityImpl();
+    activity.setId(page.getId());
+    Identity identity = new Identity("user");
+    ConversationState conversationState = new ConversationState(identity);
+    ConversationState.setCurrent(conversationState);
+    Space space = new Space();
+    space.setPrettyName("user");
+    org.exoplatform.social.core.identity.model.Identity
+        identity1 =
+        new org.exoplatform.social.core.identity.model.Identity("user");
+    when(spaceService.getSpaceByGroupId("portal1")).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity("user")).thenReturn(identity1);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(identity1);
+    when(activityManager.getActivity(page.getActivityId())).thenReturn(activity);
+    // When
+    wikiSpaceActivityPublisherSpy.postUpdatePage("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    // Then
+    //verify call method saveActivity
+    verify(wikiSpaceActivityPublisherSpy, times(1)).saveActivity("group", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+    //verify update activity
+    verify(activityManager, times(1)).updateActivity(activity, page.isToBePublished());
   }
 
 }


### PR DESCRIPTION
TASK-55861 Update Activity content even when not explicitly published
ISSUE : when saving & posting a note then get back to update the old title and content are displayed (the note activity not updated)
Fix :Update Activity content even when not explicitly published.
