### PR TITLE
Task-56989: Fix display of the informative message (#524)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -641,7 +641,8 @@ export default {
         console.error('Error when getting note', e);
         this.existingNote = false;
       }).finally(() => {
-        if (!this.note.canManage && !this.alertWarningDisplayed){
+        const alertDisplayed = localStorage.getItem(`displayAlertSpaceId-${this.spaceId}`);
+        if (!this.note.canManage && !(alertDisplayed === 'already_display')){
           const messageObject = {
             type: 'warning',
             message: `${this.$t('notes.alert.warning.label.notification')}`


### PR DESCRIPTION

Prior to this change, when closing the popup information and navigating between notes, the popup keeps on being displayed.
This PR should make sure to check if the popup was unready displayed or not