### PR TITLE
Task-57187: Missing the name of the parent page in confirmation message of deleting 

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -55,7 +55,7 @@ popup.confirmation.delete.draft=Delete draft
 popup.msg.confirmation.DeleteInfo1=Are you sure you want to send this note to the trash? {0}
 popup.msg.confirmation.DeleteInfo2=Please note:
 popup.msg.confirmation.DeleteInfo4=The links to this page will be broken when this page is removed.
-popup.msg.confirmation.DeleteInfo5=This note is child of the note: {1}
+popup.msg.confirmation.DeleteInfo5=This note is child of the note: {0}
 popup.msg.confirmation.DeleteDraftInfo1=Are you sure you want to delete this note? {0}
 popup.msg.confirmation.DeleteDraftInfo5=This draft is child of the note: {0}
 


### PR DESCRIPTION
Change the label of the confirm dialog message.