### PR TITLE
Task-55861: Add Content Length HTTP Header when reading Image Thumbnail

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -630,6 +630,16 @@ export default {
               } );
             }
           },
+          fileUploadResponse: function() {
+            /*add plugin fileUploadResponse to handle file upload response ,
+              in this method we can get the response from server and update the editor content
+              this method is called when file upload is finished*/
+            CKEDITOR.instances.notesContent.once('afterInsertHtml', ()=> {
+              window.setTimeout(() => {
+                CKEDITOR.instances.notesContent.fire('mode');
+              }, 2000);
+            });
+          },
           doubleclick: function(evt) {
             const element = evt.data.element;
             if ( element && element.is('a')) {


### PR DESCRIPTION
Prior to this change, the image  thumbnail isn't completely displayed to end user due to missing Content-Length HTTP Header.this fix will ensure to change min_Height autoGrow to true and after insert image i reload the notes content by method fire