### PR TITLE
TASK-52089: Display the list of notes filtered by  published instead of displaying the list draft of  ones 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
@@ -110,7 +110,7 @@ export default {
       if (id==='table'){
         this.$root.$emit('note-table-plugins');
       } else if ( id === 'note') {
-        this.$root.$emit('display-treeview-items');
+        this.$root.$emit('display-treeview-items', 'published');
 
       } else if ( id === 'Navigation') {
         this.instance.execCommand('ToC');

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -236,13 +236,13 @@ export default {
     this.$root.$on('show-alert', message => {
       this.displayMessage(message);
     });
-    this.$root.$on('display-treeview-items', () => {
+    this.$root.$on('display-treeview-items', filter => {
       if ( urlParams.has('noteId') ) {
-        this.$refs.noteTreeview.open(this.note, 'includePages');
+        this.$refs.noteTreeview.open(this.note, 'includePages', null, filter);
       } else if (urlParams.has('parentNoteId')) {
         this.$notesService.getNoteById(this.parentPageId).then(data => {
           const note = data;
-          this.$refs.noteTreeview.open(note, 'includePages');
+          this.$refs.noteTreeview.open(note, 'includePages', null, filter);
         });
       }
     });

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
@@ -511,13 +511,13 @@ export default {
     this.filter = this.filterOptions[0];
   },
   methods: {
-    open(note, source, includeDisplay) {
+    open(note, source, includeDisplay,filter) {
       this.render = false;
       if (note.draftPage) {
-        this.filter = this.filterOptions[1];
+        this.filter = filter === 'published' && this.filterOptions[0] || this.filterOptions[1];
         this.getDraftNote(note.id);
       } else {
-        this.filter = this.filterOptions[0];
+        this.filter = filter === 'draft' && this.filterOptions[1] || this.filterOptions[0];
         this.getNoteById(note.id);
       }
       if (source === 'includePages') {

--- a/notes-webapp/webpack.watch.js
+++ b/notes-webapp/webpack.watch.js
@@ -12,7 +12,7 @@ let config = merge(webpackCommonConfig, {
     path: path.resolve(`${exoServerPath}/webapps/${app}/`)
   },
   mode: 'development',
-  devtool: 'inline-source-map'
+  devtool: 'eval-source-map'
 });
 module.exports = config;
 


### PR DESCRIPTION
Prior to this change, when inserting a second link to a note,the filter is changed to draft is applied by default on the list of notes.
To fix this, insert the  parameter in the  event and pass  as value when opening drawer