### PR TITLE
TASK-56737 Add Space Identifier when bookmarking a note

### DIFF
--- a/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -7,12 +7,10 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.*;
-import org.exoplatform.social.common.ObjectAlreadyExistsException;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -21,8 +19,6 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.SpaceStorageException;
-import org.exoplatform.social.metadata.favorite.FavoriteService;
-import org.exoplatform.social.metadata.favorite.model.Favorite;
 import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.model.*;
 import org.exoplatform.wiki.service.*;
@@ -295,16 +291,6 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
       if (!StringUtils.isEmpty(activityId)) {
         page.setActivityId(activityId);
         noteService.updateNote(page);
-      }
-
-      if (page.getMetadatas()!=null && !page.getMetadatas().isEmpty()) {
-        FavoriteService favoriteService = CommonsUtils.getService(FavoriteService.class);
-        Favorite favorite = new Favorite("activity", activity.getId(), "", Long.parseLong(userIdentity.getId()));
-        try {
-          favoriteService.createFavorite(favorite);
-        } catch (ObjectAlreadyExistsException e) {
-          LOG.warn("Metadata item already exist for activity with id {}", activity.getId(), e);
-        }
       }
     }
   }

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/ExoNotesFavoriteAction.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/ExoNotesFavoriteAction.vue
@@ -37,7 +37,7 @@ export default {
     },
   },
   data: () => ({
-    spaceId: null,
+    spaceId: eXo.env.portal.spaceId,
     templateParams: {},
   }),
   computed: {


### PR DESCRIPTION
Prior to this change, the bookmarked note didn't had a space identifier attached into it which avoids bookmarks deletion when the space is deleted as well. This change introduces the space identifier in re-usable favorite button properties. In addition, a change has been made in WikiSpaceActivityPublisher to avoid duplicating favorite item for the activity.