### PR TITLE
Task-56296: unable to import note (#551)

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1224,9 +1224,16 @@ public class NoteServiceImpl implements NoteService {
 
           }
           if (conflict.equals("duplicate")) {
-            int i = 1;
+            String title = note.getTitle();
+            int i;
+            try {
+              i = title.lastIndexOf("_") != -1 ? Integer.valueOf(title.substring(title.lastIndexOf("_") + 1)) + 1 : 1;
+            } catch (NumberFormatException e) {
+              i = 1;
+            }
             String newTitle = note.getTitle() + "_" + i;
-            while (getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), newTitle) != null) {
+            while (getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), newTitle) != null ||
+                    isExisting(wiki.getType(), wiki.getOwner(), TitleResolver.getId(newTitle, false))) {
               i++;
               newTitle = note.getTitle() + "_" + i;
             }


### PR DESCRIPTION
Prior to this fix, when user try to reimport note and chose the duplicate action, An error message is displayed and pages notes are not imported “note already exists”
With this fix, we will be able to duplicate any note with change the name of page duplicated (increment the number) if it exists.