### PR TITLE
Task-54428: WYS is not WYG when adding a video to a note

### DIFF
--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/ckeditor/plugins/video/video.css
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/ckeditor/plugins/video/video.css
@@ -1,11 +1,15 @@
 .video {
-  width: 900px;
-  /* default value is calculated from the youtube default ratio (56.24%) with a 900px width (900*0.5624=506) */
-  height: 506px;
-  margin: 0 auto;
+    position: relative;
+    clear: both;
+    width: 80%;
+    height: 0;
+    padding-bottom: 33.74%;
+    margin: 15px auto;
 }
 
 .video iframe {
-  width: 100%;
-  height: 100%;
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 100%;
 }

--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -253,7 +253,7 @@
     .video {
       position: relative;
       clear: both;
-      width: 60%;
+      width: 80%;
       height: 0;
       padding-bottom: 33.74%;
       margin: 15px auto;


### PR DESCRIPTION
Prior this change,we don't have the same video display in the note editor and in the note detail page.