### PR TITLE
TASK-51720: Browser goBack is not considered in notes custom Urls navigation

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -326,6 +326,7 @@ export default {
       childNodes: [],
       exportStatus: '', 
       exportId: 0,
+      popStateChange: false
     };
   },
   watch: {
@@ -493,19 +494,27 @@ export default {
     this.$root.$on('import-notes', (uploadId,overrideMode) => {
       this.importNotes(uploadId,overrideMode);
     });
+    window.addEventListener('popstate', () => {
+      this.currentPath = window.location.pathname;
+      this.popStateChange = true;
+      this.handleChangePages();
+    });
   },
   mounted() {
-    if (this.noteId) {
-      if (this.isDraft) {
-        this.getDraftNote(this.noteId);
-      } else {
-        this.getNoteById(this.noteId);
-      }
-    } else {
-      this.getNoteByName(this.notesPageName);
-    }
+    this.handleChangePages();
   },
   methods: {
+    handleChangePages() {
+      if (this.noteId) {
+        if (this.isDraft) {
+          this.getDraftNote(this.noteId);
+        } else {
+          this.getNoteById(this.noteId);
+        }
+      } else {
+        this.getNoteByName(this.notesPageName);
+      }
+    },
     getHomeTitle(title) {
       return title === 'Home' && this.$t('notes.label.noteHome') || title;
     },
@@ -857,7 +866,10 @@ export default {
     updateURL(){
       const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
       notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}`;
-      window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
+      if (!this.popStateChange) {
+        window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
+      }
+      this.popStateChange = false;
     }
   }
 };


### PR DESCRIPTION
Prior to this change, no popstate event was handled for custom URLs change inside notes app to consider the goback and forward browser navigation buttons.
This PR should add a popState listener to handle the URLs changes for better ux in notes navigation