### PR TITLE
Task-57855 : unable to create a wiki when using apache front

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -57,6 +57,7 @@ import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.model.DraftPage;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.Wiki;
+import org.exoplatform.wiki.model.WikiType;
 import org.exoplatform.wiki.resolver.TitleResolver;
 import org.exoplatform.wiki.service.*;
 import org.exoplatform.wiki.service.impl.BeanToJsons;
@@ -130,6 +131,10 @@ public class NotesRestService implements ResourceContainer {
                           String source) {
     try {
       Identity identity = ConversationState.getCurrent().getIdentity();
+      if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
+        noteBookOwner = validateGroupWikiOwner(noteBookOwner);
+      }
+
       Wiki noteBook = null;
       noteBook = noteBookService.getWikiByTypeAndOwner(noteBookType, noteBookOwner);
       if (noteBook == null) {
@@ -476,6 +481,10 @@ public class NotesRestService implements ResourceContainer {
       return Response.status(Response.Status.BAD_REQUEST).entity("{ message: Note's title should not be number}").build();
     }
     try {
+      if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
+        noteBookOwner = validateGroupWikiOwner(noteBookOwner);
+      }
+
       Identity identity = ConversationState.getCurrent().getIdentity();
       Page note_ = noteService.getNoteOfNoteBookByName(noteBookType, noteBookOwner, noteId);
       if (note_ == null) {
@@ -664,6 +673,10 @@ public class NotesRestService implements ResourceContainer {
                              String noteId) {
 
     try {
+      if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
+        noteBookOwner = validateGroupWikiOwner(noteBookOwner);
+      }
+
       Identity identity = ConversationState.getCurrent().getIdentity();
       Page note_ = noteService.getNoteOfNoteBookByName(noteBookType, noteBookOwner, noteId, identity);
       if (note_ == null) {
@@ -1310,6 +1323,19 @@ public class NotesRestService implements ResourceContainer {
     content = content.replace(oldChildrenContainer, childrenContainer);
     note.setContent(content);
     return noteService.updateNote(note);
+  }
+
+  private String validateGroupWikiOwner(String wikiOwner) {
+    if (wikiOwner == null || wikiOwner.length() == 0) {
+      return null;
+    }
+    if (!wikiOwner.startsWith("/")) {
+      wikiOwner = "/" + wikiOwner;
+    }
+    if (wikiOwner.endsWith("/")) {
+      wikiOwner = wikiOwner.substring(0, wikiOwner.length() - 1);
+    }
+    return wikiOwner;
   }
 
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -132,7 +132,7 @@ public class NotesRestService implements ResourceContainer {
     try {
       Identity identity = ConversationState.getCurrent().getIdentity();
       if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
-        noteBookOwner = validateGroupWikiOwner(noteBookOwner);
+        noteBookOwner = formatWikiOwnerToGroupId(noteBookOwner);
       }
 
       Wiki noteBook = null;
@@ -482,7 +482,7 @@ public class NotesRestService implements ResourceContainer {
     }
     try {
       if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
-        noteBookOwner = validateGroupWikiOwner(noteBookOwner);
+        noteBookOwner = formatWikiOwnerToGroupId(noteBookOwner);
       }
 
       Identity identity = ConversationState.getCurrent().getIdentity();
@@ -674,7 +674,7 @@ public class NotesRestService implements ResourceContainer {
 
     try {
       if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
-        noteBookOwner = validateGroupWikiOwner(noteBookOwner);
+        noteBookOwner = formatWikiOwnerToGroupId(noteBookOwner);
       }
 
       Identity identity = ConversationState.getCurrent().getIdentity();
@@ -1325,7 +1325,7 @@ public class NotesRestService implements ResourceContainer {
     return noteService.updateNote(note);
   }
 
-  private String validateGroupWikiOwner(String wikiOwner) {
+  private String formatWikiOwnerToGroupId(String wikiOwner) {
     if (wikiOwner == null || wikiOwner.length() == 0) {
       return null;
     }


### PR DESCRIPTION
Before this fix, when using apache frontend, when wikiOwner is used as pathParam, there are 2 slash in the url. The front remove one of this slash so the wiki owner is not the good one