### PR TITLE
TASK-59178: Use PATCH annotation from Meeds WS implementation

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -70,7 +70,7 @@ import org.exoplatform.wiki.utils.NoteConstants;
 import org.exoplatform.wiki.utils.Utils;
 
 import io.swagger.annotations.*;
-import io.swagger.jaxrs.PATCH;
+import org.exoplatform.services.rest.http.PATCH;
 
 @Path("/notes")
 @Api(value = "/notes", description = "Managing notes")


### PR DESCRIPTION
Prior to this change, Endpoints with http patch requests are using the swagger jaxrs PATCH annotation,
This PR should use the PATCH annotation from Meeds WS implementation instead of swagger jaxrs annotation