### PR TITLE
TASK-52149: Different titles style between edition and saved notes

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -265,6 +265,10 @@
         height: 100%;
       }
     }
+
+    h1, h2, h3, h4, h5, h6 {
+      font-weight: normal !important;
+    }
   }
 
   table {


### PR DESCRIPTION
Prior to this change, in edition heading 1,2 and 3 are not bold, and when the note is saved they change to bold .
To fix this, change the default text style from bold to normal .