### PR TITLE
fix: Fix different titles style between edition and saved notes - TASK-52149 - Meeds-io/notes#610 

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -265,6 +265,19 @@
         height: 100%;
       }
     }
+
+    h1, h2, h3 {
+      font-weight: bold !important;
+    }
+    h1 {
+      font-size: 32px !important;
+    }
+    h2 {
+      font-size: 24px !important;
+    }
+    h3 {
+      font-size: 18.5px !important;
+    }
   }
 
   table {

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -550,7 +550,9 @@ export default {
           removePlugins = `${removePlugins},${ckEditorRemovePlugins}`;
         }
       }
-
+      CKEDITOR.addCss('h1 { font-size: 32px;font-weight: bold;}');
+      CKEDITOR.addCss('h2 { font-size: 24px;font-weight: bold;}');
+      CKEDITOR.addCss('h3 { font-size: 18.5px;font-weight: bold;}');
       CKEDITOR.addCss('.cke_editable { font-size: 14px;}');
       CKEDITOR.addCss('.placeholder { color: #5f708a!important;}');
 


### PR DESCRIPTION
Prior to this change, in edition heading 1,2 and 3 are not bold, and when the note is saved they change to bold . To fix this, change the style (font-size and font-weight) of text `h1`,`h2` and `h3`.