### PR TITLE
TASK-59276: Improve protection to protect REST services 

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -726,10 +726,10 @@ public class NotesRestService implements ResourceContainer {
     }
   }
 
-  @POST
+  @GET
   @Path("/note/export/{exportId}/{notes}")
   @RolesAllowed("users")
-  @ApiOperation(value = "Export notes", httpMethod = "PUT", response = Response.class, notes = "This export selected notes and provide a zip file.")
+  @ApiOperation(value = "Export notes", httpMethod = "GET", response = Response.class, notes = "This export selected notes and provide a zip file.")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Request fulfilled"),
       @ApiResponse(code = 400, message = "Invalid query input"), @ApiResponse(code = 403, message = "Unauthorized operation"),
       @ApiResponse(code = 404, message = "Resource not found") })
@@ -787,7 +787,7 @@ public class NotesRestService implements ResourceContainer {
     }
   }
 
-  @PUT
+  @GET
   @Path("/note/export/cancel/{exportId}")
   @RolesAllowed("users")
   @Produces(MediaType.APPLICATION_JSON)

--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
@@ -278,7 +278,7 @@ export function exportNotes(notes,exportAll,exportId) {
 
   fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/note/export/${exportId}/${notes}?exportAll=${exportAll}`, {
     credentials: 'include',
-    method: 'POST',
+    method: 'GET',
   }).then((resp) => {
     if (!resp || !resp.ok) {
       throw new Error('error', resp);
@@ -316,7 +316,7 @@ export function getExportStatus(exportId) {
 export function cancelExportNotes(exportId) {
   return fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/note/export/cancel/${exportId}`, {
     credentials: 'include',
-    method: 'PUT',
+    method: 'GET',
   }).then((resp) => {
     if (!resp || !resp.ok) {
       throw new Error('error', resp);


### PR DESCRIPTION
Prior this change, 2 rest API endpoints **exportNote()** and **cancelExportNote()** have https://github.com/post as HTTP method but doesn't write in DATABASE so they need to be changed to @get