### PR TITLE
fix: add missing jsoup dependency to Meeds server - Meeds-io/meeds#315

### DIFF
--- a/notes-packaging/src/main/assemblies/notes-addon-package.xml
+++ b/notes-packaging/src/main/assemblies/notes-addon-package.xml
@@ -43,6 +43,7 @@
         <include>${project.groupId}:*:jar</include>
         <include>commons-configuration:commons-configuration:jar</include>
         <include>org.suigeneris:jrcs.rcs:jar</include>
+        <include>org.jsoup:jsoup:jar</include>
       </includes>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <useProjectArtifact>false</useProjectArtifact>


### PR DESCRIPTION
The Jsoup library is used for indexing note pages. 
After upgrading some dependencies, the final packaging of the server missed this library, thus an exception was thrown when the Elastic search connector starts to index the note.
The fix adds Jsoup library to the packaging of the notes addon to make sure it is included in the resulting server.

