### PR TITLE
fix: Can't add an image for a new note - EXO-59684 - Meeds-io/meeds#324

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
@@ -97,6 +97,7 @@ export default {
   methods: {
     open() {
       this.$refs.customPluginsDrawer.open();
+      this.$root.$emit('initCkeditor');
     },
     close() {
       this.$refs.customPluginsDrawer.close();

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -281,6 +281,7 @@ export default {
   mounted() {
     if (this.spaceId) {
       this.init();
+      this.$root.$on('initCkeditor',() => this.initCKEditor());
     }
   },
   methods: {


### PR DESCRIPTION

Prior to this change, when we try to import an exported note with images in its content, the imported note images disappear. After this change, we ensure to process the imported note content in order to generate the adequate images links.