### PR TITLE
fix: New note : can't add an image - EXO-59684 - Meeds-io/meeds#324

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -281,7 +281,10 @@ export default {
   mounted() {
     if (this.spaceId) {
       this.init();
-      this.$root.$on('initCkeditor',() => this.initCKEditor());
+      this.$root.$on('initCkeditor',() => {
+        this.initCKEditor();
+        CKEDITOR.instances.notesContent.fire('mode');
+      });
     }
   },
   methods: {


### PR DESCRIPTION
Prior to this change, when creating a new note and clicking on the upload image button from the insert plugin drawer of notes ckeditor, the upload form is well displayed but the upload process does not finish correctly.
After this commit, to fix the problem, we try to init the ckeditor when opening the notes custom plugins.