### PR TITLE
fix: Image can't be saved after selection from computer -EXO-60730- Meeds-io/meeds-409

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -532,7 +532,7 @@ export default {
     },
     addNote() {
       if (!this.hasDraft) {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&appName=${this.appName}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&appName=${this.appName}`, '_blank');
       }
     },
     editNote() {


### PR DESCRIPTION
Prior to this change, when creating a new note and clicking on the upload image button from the insert plugin drawer of notes ckeditor, the upload process does not finish correctly. After this change the upload process works correctly for all browsers.