### PR TITLE
fix: History version drawer is empty - EXO-60449 - meeds#442

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
@@ -449,6 +449,7 @@ public class EntityConverter {
     PageHistory pageHistory = null;
     if (pageVersionEntity != null) {
       pageHistory = new PageHistory();
+      pageHistory.setId(pageVersionEntity.getId());
       pageHistory.setVersionNumber(pageVersionEntity.getVersionNumber());
       pageHistory.setAuthor(pageVersionEntity.getAuthor());
       pageHistory.setContent(pageVersionEntity.getContent());

--- a/notes-service/src/main/java/org/exoplatform/wiki/model/PageHistory.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/model/PageHistory.java
@@ -25,6 +25,8 @@ import lombok.Data;
 @Data
 public class PageHistory {
 
+  private Long   id;
+
   private Long   versionNumber;
 
   private String author;


### PR DESCRIPTION
Prior to this fix the history version of a note that already had versions is totally empty. since for notes the id is not added to the object.