### PR TITLE
 fix: notes favIcon bug - EXO-61827

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/ExoNotesFavoriteAction.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/ExoNotesFavoriteAction.vue
@@ -1,5 +1,6 @@
 <template>
   <favorite-button
+    :key="note.id"
     :id="note.id"
     :favorite="isFavorite"
     :absolute="absolute"


### PR DESCRIPTION
Prior to this change, Fav icon is colored in yellow even though these notes aren't bookmarked because the favorite-button component displays the first selected data.
after this change, the Added attribute key is used to force the changes when the data changes
