### PR TITLE
fix: fix displaying empty version drawer - EXO-62185

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -239,7 +239,7 @@
       :default-path="defaultPath"
       @open-treeview="$refs.notesBreadcrumb.open(note, 'movePage')"
       @export-pdf="createPDF(note)"
-      @open-history="openNoteVersionsHistoryDrawer(noteVersions, isManager)"
+      @open-history="openNoteVersionsHistoryDrawer()"
       @open-treeview-export="$refs.notesBreadcrumb.open(note.id, 'exportNotes')"
       @open-import-drawer="$refs.noteImportDrawer.open()" />
     <note-treeview-drawer

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -239,7 +239,7 @@
       :default-path="defaultPath"
       @open-treeview="$refs.notesBreadcrumb.open(note, 'movePage')"
       @export-pdf="createPDF(note)"
-      @open-history="$refs.noteVersionsHistoryDrawer.open(noteVersions,isManager)"
+      @open-history="openNoteVersionsHistoryDrawer(noteVersions, isManager)"
       @open-treeview-export="$refs.notesBreadcrumb.open(note.id, 'exportNotes')"
       @open-import-drawer="$refs.noteImportDrawer.open()" />
     <note-treeview-drawer


### PR DESCRIPTION
before this modification, when opening the versions drawer from the dropdown menu, the drawer was empty because no versionPageSize was defined
after this modification, the version page size is defined (in this function openNoteVersionsHistoryDrawer) and the drawer is opened and the versions are displayed successfully.