### PR TITLE
fix:Standardize font styles/size between notes and news pages - EXO-61667 - Meeds-io/meeds#641

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -268,16 +268,28 @@
     }
 
     h1, h2, h3 {
-      font-weight: bold !important;
+      font-weight: 400 !important;
     }
+    
     h1 {
-      font-size: 32px !important;
+      font-size: 34px !important;
     }
+    
     h2 {
-      font-size: 24px !important;
+      font-size: 28px !important;
     }
+    
     h3 {
-      font-size: 18.5px !important;
+      font-size: 21.84px !important;
+    }
+    
+    p, li {
+      font-size:18.6667px !important;
+    }
+    
+    blockquote p {
+      font-size:17.5px !important;
+      font-weight: 300 !important;
     }
   }
 

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -551,9 +551,11 @@ export default {
           removePlugins = `${removePlugins},${ckEditorRemovePlugins}`;
         }
       }
-      CKEDITOR.addCss('h1 { font-size: 32px;font-weight: bold;}');
-      CKEDITOR.addCss('h2 { font-size: 24px;font-weight: bold;}');
-      CKEDITOR.addCss('h3 { font-size: 18.5px;font-weight: bold;}');
+      CKEDITOR.addCss('h1 { font-size: 34px;font-weight: 400;}');
+      CKEDITOR.addCss('h2 { font-size: 28px;font-weight: 400;}');
+      CKEDITOR.addCss('h3 { font-size: 21.84px;font-weight: 400;}');
+      CKEDITOR.addCss('p,li { font-size: 18.6667px;}');
+      CKEDITOR.addCss('blockquote p  { font-size: 17.5px;font-weight: 300;}');
       CKEDITOR.addCss('.cke_editable { font-size: 14px;}');
       CKEDITOR.addCss('.placeholder { color: #5f708a!important;}');
 


### PR DESCRIPTION
Prior to this change, font styles and size were not standardized between different views in notes and news. After this change, some css style are applied on headline ,bulleted-list, numbered-list and block quote to be standardize with notes pages.