### PR TITLE
 fix:Standardize font styles/size - EXO-61667 - Meeds-io/meeds#641

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -250,7 +250,6 @@
   }
   .notes-application-content {
     overflow: auto;
-    line-height: 1.4;
     min-height: calc(~"100vh - 350px");
     .video {
       position: relative;
@@ -286,6 +285,7 @@
     
     p, li {
       font-size:18.6667px !important;
+      line-height: 1.4 !important;
     }
     
     blockquote p {


### PR DESCRIPTION
Prior to this change, font styles and size were not standardized between different views in notes . After this change, some css style are applied on headline ,bulleted-list, numbered-list and block quote to be standardize with notes pages.