### PR TITLE
fix: Display Notes Editor Page in standalone mode - Meeds-io/meeds#755 - MEED-1912

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/portal/global/pages.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/portal/global/pages.xml
@@ -26,6 +26,7 @@
     <title>Notes Editor</title>
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
+    <show-max-window>true</show-max-window>
     <container id="top-notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
       <name>top-notes-editor-container</name>
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>


### PR DESCRIPTION
Prior tot this change, the sticky mode of hamburger menu makes the notes editor displays not in full page. This change will enable Standalone page display for notes editor.