### PR TITLE
fix: Display Notes Editor Page in standalone mode - Meeds-io/meeds#755 - MEED-1912 

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/portal/global/pages.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/portal/global/pages.xml
@@ -19,13 +19,15 @@
 -->
 <page-set
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
-        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_9 http://www.gatein.org/xml/ns/gatein_objects_1_9"
+        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_9">
   <page>
     <name>notes-editor</name>
     <title>Notes Editor</title>
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
+    <show-max-window>true</show-max-window>
+    <hide-shared-layout>true</hide-shared-layout>
     <container id="top-notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
       <name>top-notes-editor-container</name>
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -548,11 +548,11 @@ export default {
     },
     addNote() {
       if (!this.hasDraft) {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&appName=${this.appName}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&appName=${this.appName}&showMaxWindow=true&hideSharedLayout=true`, '_blank');
       }
     },
     editNote() {
-      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}&parentNoteId=${this.note.parentPageId ? this.note.parentPageId : this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&appName=${this.appName}&isDraft=${this.isDraft}`, '_blank');
+      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}&parentNoteId=${this.note.parentPageId ? this.note.parentPageId : this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&appName=${this.appName}&isDraft=${this.isDraft}&showMaxWindow=true&hideSharedLayout=true`, '_blank');
     },
     deleteNote() {
       if (this.hasDraft) {


### PR DESCRIPTION
Prior tot this change, the sticky mode of hamburger menu makes the notes editor displays not in full page. This change will enable Standalone page display for notes editor even on existing editors. See https://github.com/Meeds-io/gatein-portal/pull/554#issue-1621579797 for more details about newly introduced feature.