### PR TITLE
fix: Hide unnecessary warning alert message for note access without edit permission - EXO-62612 Meeds-io/meeds#840

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -647,13 +647,6 @@ export default {
         console.error('Error when getting note', e);
         this.existingNote = false;
       }).finally(() => {
-        if (!this.note.canManage && !this.alertWarningDisplayed){
-          const messageObject = {
-            type: 'warning',
-            message: `${this.$t('notes.alert.warning.label.notification')}`
-          };
-          this.displayMessage(messageObject, true);
-        }
         this.$root.$applicationLoaded();
         this.$root.$emit('refresh-treeView-items', this.note);
       });
@@ -681,14 +674,6 @@ export default {
         console.error('Error when getting note', e);
         this.existingNote = false;
       }).finally(() => {
-        const alertDisplayed = localStorage.getItem(`displayAlertSpaceId-${this.spaceId}`);
-        if (!this.note.canManage && !(alertDisplayed === 'already_display')){
-          const messageObject = {
-            type: 'warning',
-            message: `${this.$t('notes.alert.warning.label.notification')}`
-          };
-          this.displayMessage(messageObject, true);
-        }
         this.$root.$applicationLoaded();
         this.$root.$emit('refresh-treeView-items', this.note);
       });


### PR DESCRIPTION
Before this change, when a space had a redactor and a member of the space read a note, a warning message would appear stating: **Only redactors and managers can add or modify a note. Please contact the space manager**. This change will hide the unnecessary warning message.