### PR TITLE
feat: Enable Push notifications Channel when addon installed - MEED-2062 - Meeds-io/meeds#900

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/notification-configuration.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/notification-configuration.xml
@@ -112,7 +112,7 @@
         </value-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="push-notifications">
       <name>push.channel.wiki.template</name>
       <set-method>registerTemplateProvider</set-method>
       <type>org.exoplatform.wiki.notification.provider.MobilePushTemplateProvider</type>


### PR DESCRIPTION
Prior to this change, Push notification channel was configured even when the addon isn't installed. This change will add this configuration only when push-notifications addon is added.