### PR TITLE
fix: ok button disabled when inserting image for a not saved note -EXO-64433 -  Meeds-io/meeds#944

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -316,9 +316,6 @@ export default {
     },
     getNote(id) {
       return this.$notesService.getLatestDraftOfPage(id).then(latestDraft => {
-        if (latestDraft.wikiType === 'group') {
-          this.spaceGroupId = latestDraft.wikiOwner;
-        }
         this.init();
         // check if page has a draft
         latestDraft = Object.keys(latestDraft).length !== 0 ? latestDraft : null;
@@ -340,9 +337,6 @@ export default {
     },
     getDraftNote(id) {
       return this.$notesService.getDraftNoteById(id).then(data => {
-        if (data.wikiType === 'group') {
-          this.spaceGroupId = data.wikiOwner;
-        }
         this.init();
         this.fillNote(data);
       }).finally(() => {


### PR DESCRIPTION
Prior to this change, when editing a draft created in note create note, click the insert image button, then select upload from computer option and select image from your device the image download is blocked at 100% without uploading. To fix this problem, when initialized the ckeditor pass the spaceGroupId value appropriately After this change, The image should be well uploaded and added in the draft body.

(cherry picked from commit e729774c2aa756c7a0d3ce8d88efad53d6a90e65)