### PR TITLE
fix : [Notes] insert position is wrong EXO-65312 - Meeds-io/meeds#1019

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
@@ -97,7 +97,6 @@ export default {
   methods: {
     open() {
       this.$refs.customPluginsDrawer.open();
-      this.$root.$emit('initCkeditor');
     },
     close() {
       this.$refs.customPluginsDrawer.close();


### PR DESCRIPTION
Prior to this change, when create new notes page, add 3 lines of content and on 4th line insert an image,this image inserted on top of notes content . To fix this problem, remove the reset of the ckeditor when opening the `customPluginsDrawer` drawer. After this change, image inserted at last cursor position.