### PR TITLE
fix : insert position is wrong EXO-65312 - Meeds-io/meeds#1019

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NoteCustomPlugins.vue
@@ -97,7 +97,6 @@ export default {
   methods: {
     open() {
       this.$refs.customPluginsDrawer.open();
-      this.$root.$emit('initCkeditor');
     },
     close() {
       this.$refs.customPluginsDrawer.close();

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -281,14 +281,15 @@ export default {
   mounted() {
     if (this.spaceId) {
       this.init();
-      this.$root.$on('initCkeditor',() => this.initCKEditor());
     }
   },
   methods: {
     init() {
-      this.initCKEditor();
-      this.setToolBarEffect();
-      this.initDone = true;
+      setTimeout(() => {
+        this.initCKEditor();
+        this.setToolBarEffect();
+        this.initDone = true;
+      },200);
     },
     autoSave() {
       // No draft saving if init not done or in edit mode for the moment


### PR DESCRIPTION
Prior to this change, when create new notes page, add 3 lines of content and on 4th line insert an image, this image inserted on top of notes content . To fix this problem, remove the reset of the ckeditor when opening the customPluginsDrawer drawer and add a setTimeout with 2 ms to initCKEditor . After this change, image inserted at last cursor position.