### PR TITLE
fix: error when searching notes - EXO-65101 - Meeds-io/meeds#1038

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -129,13 +129,7 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
                                      long limit) {
     term = removeSpecialCharacters(term);
     term = StringUtils.isBlank(term) ? "*:*" : term;
-    List<String> termsQuery = Arrays.stream(term.split(" ")).filter(StringUtils::isNotBlank).map(word -> {
-      word = word.trim();
-      if (word.length() > 5) {
-        word = word + "~1";
-      }
-      return word;
-    }).collect(Collectors.toList());
+    List<String> termsQuery = Arrays.stream(term.split(" ")).filter(StringUtils::isNotBlank).map(word -> "*" + word + "*").collect(Collectors.toList());
     Map<String, List<String>> metadataFilters = buildMetadataFilter(isFavorites, userId);
     String metadataQuery = buildMetadataQueryStatement(metadataFilters);
     String termQuery = StringUtils.join(termsQuery, " AND ");
@@ -200,12 +194,6 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
       SearchResultType type = SearchResultType.PAGE;
       String pageName = (String) hitSource.get("name");
       String attachmentName = null;
-
-      // Result can be an attachment
-      if (((JSONObject) jsonHit).get("_type").equals("wiki-attachment")) {
-        pageName = (String) hitSource.get("pageName");
-        attachmentName = (String) hitSource.get("name");
-      }
 
       // Get the excerpt
       JSONObject hitHighlight = (JSONObject) ((JSONObject) jsonHit).get("highlight");

--- a/notes-service/src/main/resources/notes-search-query.json
+++ b/notes-service/src/main/resources/notes-search-query.json
@@ -11,14 +11,6 @@
           }
         }
       ],
-      "should": {
-        "match_phrase": {
-          "attachment.content": {
-            "query": "@term@",
-            "boost": 5
-          }
-        }
-      },
       "must":{
         "query_string":{
           "fields": ["name","title^5","content","comment","attachment.content"],


### PR DESCRIPTION
Priori to this fix a NullPointerException was thrown when there are search results for Notes.
The error is thrown because we used to index and search Notes attachments, which is no more the case thanks to the curent fix. It also enhances search results by appending the :star: character to searched words
