### PR TITLE
fix: return child notes sorted with natural sorting rule - EXO-46735 - Meeds-io/meeds#1056

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/TreeNode.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/TreeNode.java
@@ -20,6 +20,7 @@
 package org.exoplatform.wiki.tree;
 
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.comparators.NaturalComparator;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.Wiki;
 import org.exoplatform.wiki.service.WikiPageParams;
@@ -193,6 +194,7 @@ public class TreeNode {
   public void pushDescendants(HashMap<String, Object> context, String userId) throws Exception {
     addChildren(context, userId);
     pushChildren(context, userId);
+    this.children = this.children.stream().sorted((childItem1, childItem2) -> new NaturalComparator().compare(childItem1.getName(), childItem2.getName())).toList();
   }
   
   protected void addChildren(HashMap<String, Object> context, String userId) throws Exception {


### PR DESCRIPTION
The current fix reuses the Natural Comparator to sort Notes children pages in a human understadable order.
