### PR TITLE
feat: Add Notification Administration Label - MEED-2445 - Meeds-io/MIPs#79

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/NotificationAdministration_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/NotificationAdministration_en.properties
@@ -1,0 +1,1 @@
+NotificationAdmin.EditWikiNotificationPlugin=A note has been updated

--- a/notes-webapp/src/main/resources/locale/portlet/NotificationAdministration_fr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/NotificationAdministration_fr.properties
@@ -1,0 +1,1 @@
+NotificationAdmin.EditWikiNotificationPlugin=Une note a \u00E9t\u00E9 mise \u00E0 jour

--- a/translations.properties
+++ b/translations.properties
@@ -35,3 +35,4 @@ portal/global.properties=notes-webapp/src/main/resources/locale/navigation/porta
 
 # Analytics
 Analytics.properties=notes-webapp/src/main/resources/locale/portlet/Analytics_en.properties
+NotificationAdministration.properties=notes-webapp/src/main/resources/locale/portlet/NotificationAdministration_en.properties


### PR DESCRIPTION
Prior to this change, the notification label is displayed the same way in administration and user settings. This change will add a dedicated label when in administration scope.