### PR TITLE
fix: blockquotes in notes view mode are not wysiwyg - EXO-65725 - Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/editor.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/editor.less
@@ -12,7 +12,6 @@
 
     blockquote {
       font-weight: 400 !important;
-      font-style: normal !important;
       padding: 10px !important;
       border-left-color: @primaryColor !important;
       margin: 0 0 10px 0 !important;
@@ -21,6 +20,7 @@
         margin-bottom: 0 !important;
         line-height: 1.4 !important;
         font-size: 16px !important;
+        font-style: normal !important;
       }
 
       strong {


### PR DESCRIPTION
Prior to this change, blockquotes in notes view mode are not wysiwyg in term of font style. The PR makes sure to have the same normal font style in both view and edit mode