### PR TITLE
feat: Indent option is available only in lists - EXO-66446 - Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -600,7 +600,7 @@ export default {
       CKEDITOR.plugins.addExternal('toc','/notes/javascript/eXo/wiki/ckeditor/plugins/toc/','plugin.js');
 
       CKEDITOR.dtd.$removeEmpty['i'] = false;
-      let extraPlugins = 'codesnippet,sharedspace,copyformatting,table,tabletools,embedsemantic,autolink,colordialog,' +
+      let extraPlugins = 'indent,indentblock,indentlist,codesnippet,sharedspace,copyformatting,table,tabletools,embedsemantic,autolink,colordialog,' +
           'tagSuggester,emoji,link,font,justify,widget,insertOptions,contextmenu,tabletools,tableresize,toc';
       let removePlugins = 'image,confirmBeforeReload,maximize,resize,autoembed';
       const windowWidth = $(window).width();


### PR DESCRIPTION
Prior to this change, indent option is available only in lists due to missing indent plugins. 
This PR adds the needed indent extra plugins to make it available on all possible items.