### PR TITLE
fix: fix inserted image wysiwyg issue in edit mode - EXO-66452 - Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -674,6 +674,8 @@ export default {
       CKEDITOR.addCss('ol ol ol li {list-style-type: lower-roman !important;}');
       CKEDITOR.addCss('ol ol ol ol li {list-style-type: upper-latin !important;}');
       CKEDITOR.addCss('ol ol ol ol ol li {list-style-type: upper-roman !important;}');
+      CKEDITOR.addCss('span[data-cke-display-name="image"] { margin: auto;}');
+      CKEDITOR.addCss('span[data-cke-display-name="image"] span.cke_image_resizer { bottom: 0 !important;}');
 
       CKEDITOR.on('dialogDefinition', function (e) {
         if (e.data.name === 'link') {


### PR DESCRIPTION
Prior to this change, inserted images in edit mode are not consistent with images in view mode due to the added styles of spacement of the widget container, resize and drag buttons. 
This PR adds some adjustments inside the image widget container to make it consistent with the images in the edit mode