### PR TITLE
fix: Add cancel button in article creation page to return to previous page  - EXO-63301 - Meeds-io/meeds#1128

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -19,6 +19,14 @@
         <div class="notesActions white">
           <div class="notesFormButtons d-inline-flex flex-wrap width-full pa-3 ma-0">
             <div class="notesFormLeftActions d-inline-flex align-center me-10">
+              <v-btn 
+                v-if="isMobile"
+                icon
+                fab
+                class="my-auto"
+                @click="close()">
+                <v-icon> mdi-arrow-left </v-icon>
+              </v-btn>
               <img :src="srcImageNote">
               <span class="notesFormTitle ps-2">{{ noteFormTitle }}</span>
             </div>
@@ -174,6 +182,9 @@ export default {
     },
     alertMessageClass(){
       return  this.message.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, '').trim().length > 45 ? 'lengthyAlertMessage' : '';
+    },
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
   },
   watch: {
@@ -924,6 +935,9 @@ export default {
         oembed.setAttribute('style', style);
       });
       return docElement?.children[1].innerHTML;
+    },
+    close() {
+      window.close();
     }
   }
 };


### PR DESCRIPTION
Prior to this change, when click on write an notes in space alors the notes edition page opens, there is no way to quit the edition page unless I post the article.To fix this, Add the cancel button so the user can return to the previous page to space as page.