### PR TITLE
feat: Add assets version to editor content css file - EXO-65716 - Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -725,7 +725,7 @@ export default {
         },
         on: {
           instanceReady: function (evt) {
-            this.document.appendStyleSheet('/notes/skin/css/notes/editorContent.css');
+            this.document.appendStyleSheet(`/notes/skin/css/notes/editorContent.css?v=${eXo.env.client.assetsVersion}`);
             self.actualNote.content = evt.editor.getData();
             CKEDITOR.instances['notesContent'].removeMenuItem('linkItem');
             CKEDITOR.instances['notesContent'].removeMenuItem('selectImageItem');


### PR DESCRIPTION
Add assets version to editor content css file to prevent style cache load issues.