### PR TITLE
fix: Adjust wysiwyg issue in content area between view and edit mode -  EXO-66650 -  Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/editorContent.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/editorContent.less
@@ -8,6 +8,10 @@ pre {
     }
 }
 
+body {
+    margin: 19px !important;
+}
+
 h1:first-child, h2:first-child, h3:first-child {
     margin-top: 0;
 }


### PR DESCRIPTION
Prior to this change, there is a difference of 2px in terms of width inside the content area between the edit and view mode which cause a wysiwyg. 
This PR adjusts the margin set in the editor content area to have the same as the view mode.