### PR TITLE
feat: Reuse centralized Toast Notifs component - MEED-2627 - Meeds-io/MIPs#99

### DIFF
--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
@@ -212,7 +212,7 @@ export function getPathByNoteOwner(note, noteAppName) {
   if (!noteAppName) {
     noteAppName = 'notes';
   }
-  if (note.wikiType === 'group') {
+  if (note.wikiType === 'group' && note?.url) {
     const spaceName = note.wikiOwner.split('/spaces/')[1];
     const spaceDisplayName = note.url.split(`/portal/g/:spaces:${spaceName}/`)[1].split('/')[0];
     return `${eXo.env.portal.context}/g/:spaces:${spaceName}/${spaceDisplayName}/${noteAppName}/${note.id}`;

--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -42,16 +42,7 @@
   }
 }
 
-.v-alert.lengthyAlertMessage {
-  max-width: 39% !important;
-}
-
 .notesEditor {
-  .v-alert__content {
-    .dropDraftLink {
-      text-decoration: underline;
-    }
-  }
   
   .customTableDrawer {
     z-index: 99999 !important;
@@ -60,10 +51,6 @@
       font-style: normal;
       font-size: 22px;
     }
-  }
-
-  .v-alert {
-    z-index: 99999 !important;
   }
 
   #notesEditor {

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -1,17 +1,5 @@
 <template>
   <v-app class="notesEditor">
-    <v-alert
-      v-model="alert"
-      :class="alertMessageClass"
-      :type="alertType"
-      :icon="alertType === 'warning' ? 'mdi-alert-circle' : ''"
-      dismissible>
-      {{ message }}
-      <a 
-        v-if="alertType === 'warning' && note.draftPage" 
-        class="dropDraftLink"
-        @click="dropDraft">{{ $t('notes.label.drop.draft') }}</a>
-    </v-alert>
     <div
       id="notesEditor"
       class="notesEditor width-full">
@@ -171,9 +159,6 @@ export default {
     initCompleted() {
       return this.initDone && ((this.initActualNoteDone || this.noteId) || (this.initActualNoteDone || !this.noteId)) ;
     },
-    alertMessageClass(){
-      return  this.message.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, '').trim().length > 45 ? 'lengthyAlertMessage' : '';
-    },
   },
   watch: {
     'note.title'() {
@@ -235,9 +220,7 @@ export default {
     this.$root.$on('updateData', data => {
       this.note.content= data;
     });
-    this.$root.$on('show-alert', message => {
-      this.displayMessage(message);
-    });
+    this.$root.$on('show-alert', this.displayMessage);
     this.$root.$on('display-treeview-items', filter => {
       if ( urlParams.has('noteId') ) {
         this.$refs.noteTreeview.open(this.note, 'includePages', null, filter);
@@ -322,11 +305,7 @@ export default {
         latestDraft = Object.keys(latestDraft).length !== 0 ? latestDraft : null;
         if (latestDraft) {
           this.fillNote(latestDraft);
-          const messageObject = {
-            type: 'warning',
-            message: `${this.$t('notes.alert.warning.label.draft.drop')} ${this.$dateUtil.formatDateObjectToDisplay(new Date(this.note.updatedDate.time), this.dateTimeFormat, this.lang)},`
-          };
-          this.displayMessage(messageObject, true);
+          this.displayDraftMessage();
           this.initActualNoteDone = true;
         } else {
           this.$notesService.getNoteById(id).then(data => {
@@ -341,11 +320,7 @@ export default {
         this.init();
         this.fillNote(data);
       }).finally(() => {
-        const messageObject = {
-          type: 'warning',
-          message: `${this.$t('notes.alert.warning.label.draft.drop')} ${this.$dateUtil.formatDateObjectToDisplay(new Date(this.note.updatedDate.time), this.dateTimeFormat, this.lang)},  `
-        };
-        this.displayMessage(messageObject, true);
+        this.displayDraftMessage();
         this.initActualNoteDone = true;
       });
     },
@@ -743,13 +718,24 @@ export default {
         return true;
       }
     },
-    displayMessage(message, keepAlert) {
-      this.message = message.message;
-      this.alertType = message.type;
-      this.alert = true;
-      if (!keepAlert) {
-        window.setTimeout(() => this.alert = false, 5000);
-      }
+    displayDraftMessage() {
+      this.displayMessage({
+        type: 'warning',
+        message: `
+          <span class="pe-1">${this.$t('notes.alert.warning.label.draft.drop')}</span>
+          <span>${this.$dateUtil.formatDateObjectToDisplay(new Date(this.note.updatedDate.time), this.dateTimeFormat, this.lang)}</span>
+        `,
+        linkText: this.$t('notes.label.drop.draft'),
+        linkCallback: () => this.dropDraft(),
+      });
+    },
+    displayMessage(message) {
+      document.dispatchEvent(new CustomEvent('alert-message-html', {detail: {
+        alertMessage: message?.message,
+        alertType: message?.type,
+        alertLinkText: message?.linkText,
+        alertLinkCallback: message?.linkCallback,
+      }}));
     },
     displayFormTitle() {
       if (this.noteId) {


### PR DESCRIPTION
Prior to this change, the used toast notifications wasn't relying on the centralized reusable component to display alerts. This change removes the specific alerts in order to reuse the centralized component.