### PR TITLE
feat: Reuse centralized Toast Notifs component - MEED-2627 - Meeds-io/MIPs#99

### DIFF
--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
@@ -212,7 +212,7 @@ export function getPathByNoteOwner(note, noteAppName) {
   if (!noteAppName) {
     noteAppName = 'notes';
   }
-  if (note.wikiType === 'group') {
+  if (note.wikiType === 'group' && note?.url) {
     const spaceName = note.wikiOwner.split('/spaces/')[1];
     const spaceDisplayName = note.url.split(`/portal/g/:spaces:${spaceName}/`)[1].split('/')[0];
     return `${eXo.env.portal.context}/g/:spaces:${spaceName}/${spaceDisplayName}/${noteAppName}/${note.id}`;

--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -42,16 +42,7 @@
   }
 }
 
-.v-alert.lengthyAlertMessage {
-  max-width: 39% !important;
-}
-
 .notesEditor {
-  .v-alert__content {
-    .dropDraftLink {
-      text-decoration: underline;
-    }
-  }
   
   .customTableDrawer {
     z-index: 99999 !important;
@@ -60,10 +51,6 @@
       font-style: normal;
       font-size: 22px;
     }
-  }
-
-  .v-alert {
-    z-index: 99999 !important;
   }
 
   #notesEditor {


### PR DESCRIPTION
Prior to this change, the used toast notifications wasn't relying on the centralized reusable component to display alerts. This change removes the specific alerts in order to reuse the centralized component.