### PR TITLE
feat: Allow to save draft before opening Full Notes Editor - MEED-2700 - Meeds-io/MIPs#93

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
@@ -54,7 +54,7 @@
             class="me-3"
             target="_blank"
             icon
-            @click="save">
+            @mousedown="persistDraftNote">
             <v-icon size="20">fa-external-link-alt</v-icon>
           </v-btn>
         </template>
@@ -86,10 +86,16 @@ export default {
     initialized: false,
   }),
   computed: {
+    note() {
+      return this.$root.page;
+    },
+    parentPageId() {
+      return this.note?.parentPageId;
+    },
     fullPageEditorLink() {
       const formData = new FormData();
       formData.append('noteId', this.$root.page?.id);
-      formData.append('parentNoteId', this.$root.page?.parentPageId);
+      formData.append('parentNoteId', this.parentPageId);
       if (eXo.env.portal?.spaceGroup) {
         formData.append('spaceGroupId', eXo.env.portal?.spaceGroup);
       }
@@ -133,6 +139,20 @@ export default {
         })
         .catch(() => this.$root.$emit('alert-message', this.$t('notePageView.label.errorSavingText') , 'error'))
         .finally(() => this.saving = false);
+    },
+    persistDraftNote() {
+      return this.$notesService.saveDraftNote({
+        id: this.note.id,
+        name: this.note.name,
+        title: this.note.title,
+        content: this.pageContent,
+        wikiType: this.note.wikiType,
+        wikiOwner: this.note.wikiOwner,
+        parentPageId: this.note.parentPageId,
+        targetPageId: this.note.id,
+      }, this.note.parentPageId).then(savedDraftNote => {
+        localStorage.setItem(`draftNoteId-${this.note.id}`, JSON.stringify(savedDraftNote));
+      });
     },
   }
 };

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -19,7 +19,7 @@
 
 -->
 <template>
-  <v-app v-if="canView">
+  <v-app v-if="canView" class="overflow-hidden">
     <v-hover v-slot="{ hover }">
       <v-card
         :class="viewMode && 'pa-4'"

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/services.js
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/services.js
@@ -18,7 +18,16 @@
  */
 
 import * as notePageViewService from './js/NotePageViewService.js';
+import * as notesService from '../../javascript/eXo/wiki/notesService.js';
 
-window.Object.defineProperty(Vue.prototype, '$notePageViewService', {
-  value: notePageViewService,
-});
+if (!Vue.prototype.$notePageViewService) {
+  window.Object.defineProperty(Vue.prototype, '$notePageViewService', {
+    value: notePageViewService,
+  });
+}
+
+if (!Vue.prototype.$notesService) {
+  window.Object.defineProperty(Vue.prototype, '$notesService', {
+    value: notesService,
+  });
+}


### PR DESCRIPTION
This change will save a note draft when the user clicks to open the full page notes editor to get the modifications made on quick edit.