### PR TITLE
feat: Deny concurrent Note Page editing - MEED-2702 - Meeds-io/MIPs#93

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/NotePageView_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/NotePageView_en.properties
@@ -9,3 +9,4 @@ notePageView.label.savedSuccessfully=Text has been saved
 notePageView.label.errorSavingText=An unkown error happened while saving text
 notePageView.label.removedSuccessfully=Text has been removed
 notePageView.label.errorRemovingText=An unkown error happened while removing text
+notePageView.label.warningCannotEditTwoNotes=Finish editing one piece of content before moving on to the next

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -22,11 +22,11 @@
   <v-app v-if="canView" class="overflow-hidden">
     <v-hover v-slot="{ hover }">
       <v-card
-        :class="viewMode && 'pa-4'"
+        :class="viewMode && 'pa-5'"
         min-width="100%"
         max-width="100%"
         min-height="72"
-        class="d-flex flex-column border-box-sizing position-relative"
+        class="d-flex flex-column border-box-sizing position-relative card-border-radius"
         color="white"
         flat>
         <note-page-edit
@@ -80,7 +80,10 @@ export default {
   watch: {
     edit() {
       if (this.edit) {
+        window.editNoteInProgress = true;
         this.$root.$emit('close-alert-message');
+      } else {
+        window.editNoteInProgress = false;
       }
     },
   },
@@ -90,8 +93,12 @@ export default {
   },
   methods: {
     openEditor() {
-      this.editorReady = false;
-      this.$nextTick().then(() => this.edit = true);
+      if (window.editNoteInProgress) {
+        this.$root.$emit('alert-message', this.$t('notePageView.label.warningCannotEditTwoNotes'), 'warning');
+      } else {
+        this.editorReady = false;
+        this.$nextTick().then(() => this.edit = true);
+      }
     },
     closeEditor() {
       this.editorReady = false;


### PR DESCRIPTION
This change will display a warning alert to end user when (s)he attempts to edit two single note view applications at the same time.