### PR TITLE
fix: set zero margin top of first title comes in page content - EXO-66864 - Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/editor.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/editor.less
@@ -110,7 +110,7 @@
 
       h1 {
         font-size: 28px !important;
-        margin-top: 45px !important;
+        margin-top: 45px;
       }
 
       h2 {


### PR DESCRIPTION
This PR removes the !important flag that is used to override the margin-top of first titles in the page content to have a "0" margin top.