### PR TITLE
fix: create a note is not working - EXO-67185 - Meeds-io/MIPs#70 (#816)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -535,6 +535,8 @@ export default {
             // delete draft note
             const draftNote = JSON.parse(localStorage.getItem(`draftNoteId-${this.note.id}`));
             this.deleteDraftNote(draftNote, notePath);
+            // show the created note
+            window.location.href = notePath;
           }).catch(e => {
             console.error('Error when creating note page', e);
             this.enableClickOnce();


### PR DESCRIPTION
Prior to this fix when I created a note and I clicked on save it nothing happened.
This fix opens the newly created note after being saved