### PR TITLE
fix: fix note version language favorite item issue - EXO-65766 - Meeds-io/MIPs#70

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-favorite-drawer-extension/components/favorites/NotesFavoriteItem.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-favorite-drawer-extension/components/favorites/NotesFavoriteItem.vue
@@ -42,11 +42,18 @@ export default {
       return this.note?.title || '';
     },
     noteUrl() {
-      return this.note?.url || '#';
+      return this.note.lang && `${this.note?.url}?translation=${this.note.lang}` || `${this.note?.url}?translation=original`;
     }
   },
   created() {
-    this.$notesService.getNoteById(this.id).then(note => {
+    let noteId = this.id;
+    let lang = null;
+    if (this.id.includes('-')) {
+      const parts = this.id.split('-');
+      noteId = parts[0];
+      lang = parts[1];
+    }
+    this.$notesService.getNoteById(noteId, lang).then(note => {
       this.note = note;
     });
   },

--- a/notes-webapp/src/main/webapp/vue-app/wikiSearch/components/WikiSearchCard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/wikiSearch/components/WikiSearchCard.vue
@@ -66,7 +66,7 @@ export default {
   }),
   computed: {
     wikiUrl() {
-      return this.result && this.result.url;
+      return this.result?.lang && this.result?.url || `${this.result?.url}?translation=original`;
     },
     excerpts() {
       return this.result && this.result.excerpt;


### PR DESCRIPTION
Prior to this change, note version favorite item is not well fetched and wrong url for favorite version language. 
This PR makes sure to well fetch the version language and set the correct url for the version.