### PR TITLE
 fix: update notes configuration for image storage location - EXO-64344

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -553,7 +553,7 @@ export default {
         allowedContent: true,
         spaceURL: self.spaceURL,
         spaceGroupId: `/spaces/${this.spaceGroupId}`,
-        imagesDownloadFolder: 'notes/images',
+        imagesDownloadFolder: 'DRIVE_ROOT_NODE/notes/images',
         toolbarLocation: 'top',
         extraAllowedContent: 'table[!summary]; img[style,class,src,referrerpolicy,alt,width,height]; span(*)[*]{*}; span[data-atwho-at-query,data-atwho-at-value,contenteditable]; a[*];i[*];',
         removeButtons: '',


### PR DESCRIPTION
This will set the default location of images uploaded to Notes under the root of the space instead of under the Documents folder.
