### PR TITLE
fix: fix open embedded links - EXO-65753 - Meeds-io/MIPs#71

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -557,7 +557,14 @@ export default {
     this.$root.$on('update-note-title', this.updateNoteTitle);
     this.$root.$on('update-note-content', this.updateNoteContent);
     this.$root.$on('update-selected-translation', this.updateSelectedTranslation);
-
+    window.addEventListener('message', (event) => {
+      if (event.origin === 'https://if-cdn.com') {
+        const data = JSON.parse(event.data);
+        if (data.method === 'open-href') {
+          window.open(data.href, '_blank');
+        }
+      }
+    });
   },
   mounted() {
     this.handleChangePages();


### PR DESCRIPTION
prior to this.change, embedded links are not opened directly when click, this due to a security rule that prevents events from propagating directly to the parent window, thus iframely adds a script that use the `postMessage` to communicate with parent window about the open of the link. This PR uses the event message to handle the open of links triggered from the embedded iframes of iframely