### PR TITLE
feat: Extra margin to remove when CMS portlets are not displayed - MEED-2953-Meeds-io/MIPs#103

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -102,6 +102,13 @@ export default {
         window.editNoteInProgress = false;
       }
     },
+    canView() {
+      if (this.canView) {
+        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
+      } else {
+        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+      }
+    }
   },
   created() {
     document.addEventListener('cms-preview-mode', this.switchToPreview);


### PR DESCRIPTION
Prior to this change, When we toggle between show/hide of the preview mode in the public page, an extra margin in displayed when the app is hidden.
This change allows to remove extra margin when app is hidden.