### PR TITLE
fix: fix open embedded links - EXO-65753 - Meeds-io/meeds#1306

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -303,7 +303,8 @@ export default {
       childNodes: [],
       exportStatus: '',
       exportId: 0,
-      popStateChange: false
+      popStateChange: false,
+      iframelyOriginRegex: /^https?:\/\/if-cdn.com/
     };
   },
   watch: {
@@ -527,6 +528,14 @@ export default {
       this.currentPath = window.location.pathname;
       this.popStateChange = true;
       this.handleChangePages();
+    });
+    window.addEventListener('message', (event) => {
+      if (this.iframelyOriginRegex.exec(event.origin)) {
+        const data = JSON.parse(event.data);
+        if (data.method === 'open-href') {
+          window.open(data.href, '_blank');
+        }
+      }
     });
   },
   mounted() {


### PR DESCRIPTION
prior to this.change, embedded links are not opened directly when click, this due to a security rule that prevents events from propagating directly to the parent window, thus iframely adds a script that use the `postMessage` to communicate with parent window about the open of the link.
This PR uses the event message to handle the open of links triggered from the embedded iframes of iframely