### PR TITLE
fix: Publish Note when Created - MEED-2980 - Meeds-io/meeds#1308

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -231,17 +231,12 @@ public class NoteServiceImpl implements NoteService {
       note.setOwner(userIdentity.getUserId());
       note.setAuthor(userIdentity.getUserId());
       note.setContent(note.getContent());
-      Space space = spaceService.getSpaceByGroupId(note.getWikiOwner());
       Page createdPage = createNote(noteBook, parentPage, note);
-      createdPage.setCanManage(canManageNotes(userIdentity.getUserId(), space, note));
-      createdPage.setCanImport(canImportNotes(userIdentity.getUserId(), space, note));
-      createdPage.setCanView(canViewNotes(userIdentity.getUserId(), space, note));
-      createdPage.setToBePublished(note.isToBePublished());
-      createdPage.setAppName(note.getAppName());
-      createdPage.setUrl(Utils.getPageUrl(createdPage));
-      invalidateCache(parentPage);
-      invalidateCache(note);
 
+      Space space = spaceService.getSpaceByGroupId(note.getWikiOwner());
+      createdPage.setCanManage(canManageNotes(note.getAuthor(), space, note));
+      createdPage.setCanImport(canImportNotes(note.getAuthor(), space, note));
+      createdPage.setCanView(canViewNotes(note.getAuthor(), space, note));
       return createdPage;
     } else {
       throw new EntityNotFoundException("Parent note not foond");
@@ -251,8 +246,14 @@ public class NoteServiceImpl implements NoteService {
   @Override
   public Page createNote(Wiki noteBook, Page parentPage, Page note) throws WikiException {
     Page createdPage = dataStorage.createPage(noteBook, parentPage, note);
+    createdPage.setToBePublished(note.isToBePublished());
+    createdPage.setToBePublished(note.isToBePublished());
+    createdPage.setAppName(note.getAppName());
+    createdPage.setUrl(Utils.getPageUrl(createdPage));
+    invalidateCache(parentPage);
+    invalidateCache(note);
+
     Utils.broadcast(listenerService, "note.posted", note.getAuthor(), createdPage);
-    // call listeners
     postAddPage(noteBook.getType(), noteBook.getOwner(), note.getName(), createdPage);
     return createdPage;
   }

--- a/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -256,8 +256,6 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
     try {
       Space space = spaceService.getSpaceByGroupId(wikiOwner);
       if (space != null) {
-        if (!page.isCanView())
-          return;
         ownerStream = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
         spaceUrl = space.getUrl();
         spaceName = space.getDisplayName();


### PR DESCRIPTION
Prior to this change, when creating a note and attempting to publish it, the activity isn't created. This change will fix the activity creation.