### PR TITLE
fix: Set primary text color for navigation menu - EXO-67647 - Meeds-io/meeds#1318

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteContentTableItem.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteContentTableItem.vue
@@ -21,8 +21,9 @@
 <template>
   <v-list-item
     :href="noteLink"
+    ripple
     link>
-    <span class="subtitle-1 ps-2">
+    <span class="primary--text subtitle-1 ps-2">
       {{ note.name }}
     </span>
   </v-list-item>

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -197,6 +197,7 @@
             v-if="noteChildren && noteChildren[0]"
             dense
             :items="noteAllChildren"
+            class="ps-1"
             item-key="noteId">
             <template #label="{ item }">
               <note-content-table-item :note="item" />
@@ -348,14 +349,16 @@ export default {
         data() {
           return {
             vTreeComponent: {
-              template: '<v-treeview \
-              dense \
-              :items="noteChildItems" \
-              item-key="noteId"> \
-              <template #label="{ item }"> \
-                <note-content-table-item :note="item" />\
-              </template> \
-              </v-treeview >',
+              template: `
+                <v-treeview
+                  dense
+                  :items="noteChildItems"
+                  class="ps-1"
+                  item-key="noteId">
+                  <template #label="{ item }">
+                    <note-content-table-item :note="item" />
+                  </template>
+                </v-treeview >`,
               props: {
                 noteId: 0,
                 source: '',


### PR DESCRIPTION
Prior to this change, navigation menu items are in text black color.  
This PR ensures to set the color of menu items to primary color