### PR TITLE
fix: Fix HTML codesnippet on edit - MEED-3013 - Meeds-io/meeds#1333

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/js/Utils.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/js/Utils.js
@@ -16,7 +16,6 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 export function getContentToSave(ckEditorInstanceId, oembedMinWidth) {
   const domParser = new DOMParser();
   const newData = CKEDITOR.instances[ckEditorInstanceId].getData();
@@ -82,7 +81,7 @@ export function getContentToDisplay(content, noteId, noteBookType, noteBookOwner
 
 function restoreUnHighlightedCode(documentElement) {
   documentElement.querySelectorAll('code.hljs').forEach(code => {
-    code.innerHTML = code.innerText;
+    code.innerHTML = code.innerText.replace(/</g, '&lt;').replace(/>/g, '&gt;');
     code.classList.remove('hljs');
   });
 }


### PR DESCRIPTION
Prior to this change, with the Meeds-io/MIPs#71 changes, the newly introduced codesnippet plugin isn't well interpreted when editing the RichEditor content. This change ensures to encode the content having '<' and '>' characters correctly to make the plugin interpret the result correctly.

At the same time, this will ensure to not save a draft version of the content when editing only when modified and not all time when the first time open it to edit.