### PR TITLE
fix: Fix Browser Go Back in Notes - MEED-3019 - Meeds-io/meeds#1336

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -696,12 +696,11 @@ export default {
         this.isDraft = data.draftPage;
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        this.updateURL();
         this.getNoteLanguages(noteId);
         if (!this.note.lang || this.note.lang === ''){
           this.updateSelectedTranslation(this.originalVersion);
-          this.updateURL();
         }
+        this.updateURL();
         if (viewNote){
           this.viewNoteStatistics(this.note);
         }
@@ -732,12 +731,11 @@ export default {
         this.isDraft = data.draftPage;
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
-        this.updateURL();
         this.getNoteLanguages(this.note.id);
-        if (!this.note.lang || this.note.lang === ''){
+        if (!this.note.lang || this.note.lang === '') {
           this.updateSelectedTranslation(this.originalVersion);
-          this.updateURL();
         }
+        this.updateURL();
         if (viewNote){
           this.viewNoteStatistics(this.note);
         }
@@ -916,13 +914,12 @@ export default {
     updateURL(){
       const charsToRemove = notesConstants.PORTAL_BASE_URL.length-notesConstants.PORTAL_BASE_URL.lastIndexOf(`/${this.appName}`);
       let translation = '';
-      if (this.selectedTranslation.value){
+      if (this.selectedTranslation.value) {
         translation = `?translation=${this.selectedTranslation.value}`;
       }
       notesConstants.PORTAL_BASE_URL = `${notesConstants.PORTAL_BASE_URL.slice(0,-charsToRemove)}/${this.appName}/${this.note.id}${translation}`;
-      
       if (!this.popStateChange) {
-        window.history.pushState('notes', '', notesConstants.PORTAL_BASE_URL);
+        window.history.replaceState(window.history.state, window.document.title, notesConstants.PORTAL_BASE_URL);
       }
       this.popStateChange = false;
     },


### PR DESCRIPTION
Prior to this change, when browing from a note to another one having a language set, a hidden URL is computed and pushed to history which make the Browser history not the same as the user expects. In fact, when going back to previously visited page, the same page is displayed again. This change ensures to use 'replaceState' instead of 'pushState' to replace current history entry instead of appending a new one.