### PR TITLE
fix: Fix used meta site name reference - MEED-3024 - Meeds-io/meeds#1351

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
@@ -131,7 +131,7 @@ export default {
         formData.append('translation', this.note.lang);
       }
       const urlParams = new URLSearchParams(formData).toString();
-      return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/notes-editor?${urlParams}`;
+      return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/notes-editor?${urlParams}`;
     },
     isSmall() {
       return this.$root.isSmall;


### PR DESCRIPTION
Prior to this change, the Meta site name was referenced as 'defaultPortal'. The notion of 'default' portal doesn't exist anymore and was replaced by 'meta' site with 'aggregated' sites. This change will replace to use the Meta site name where the list of referenced applications are added.