### PR TITLE
Fix: Notes - Navigation menu in a note with a text is not displayed in view mode - EXO-67951 - Meeds-io/meeds#1484

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -393,7 +393,6 @@ export default {
                 getNodeById(noteId, source, noteBookType, noteBookOwner) {
                   return this.$notesService.getNoteById(noteId,this.selectedTranslation.value, source, noteBookType, noteBookOwner).then(data => {
                     this.note = data || {};
-                    this.getNoteLanguages(noteId);
                     this.$notesService.getFullNoteTree(data.wikiType, data.wikiOwner, data.name, false,this.selectedTranslation.value).then(data => {
                       if (data && data.jsonList.length) {
                         const allNotesTreeview = data.jsonList;


### PR DESCRIPTION
Before this commit when user add text to a note and insert navigation widget, the navigation does not appear in the view mode.
This commit fix the problem