### PR TITLE
fix: Fix Image Alignment Issue After Saving - EXO-68298 - Meeds-io/meeds#1482

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -357,7 +357,7 @@ export default {
   computed: {
     notesContentProcessor() {
       return {
-        template: `<div class='reset-style-box rich-editor-content extended-rich-content'>${this.$noteUtils.getContentToDisplay(this.noteContent, this.note?.id, this.noteBookType, this.noteBookOwner, true)}</div>`,
+        template: `<div class='rich-editor-content extended-rich-content'>${this.$noteUtils.getContentToDisplay(this.noteContent, this.note?.id, this.noteBookType, this.noteBookOwner, true)}</div>`,
         data() {
           return {
             vTreeComponent: {


### PR DESCRIPTION
Prior to this change, the image was correctly aligned by the middle in height with the text while in edit mode, but after saving, it would align by the bottom with the text.This commit ensures that the image maintains a consistent vertical alignment with the text after saving.