### PR TITLE
fix: Resolve the mobile display issue related to the bulleted list - EXO-68427

### DIFF
--- a/notes-webapp/src/main/webapp/ckeditor/skins/common/custom-variables.less
+++ b/notes-webapp/src/main/webapp/ckeditor/skins/common/custom-variables.less
@@ -23,5 +23,4 @@
 @ckEditableLineHeight: 1.4;
 @titleFontWeight: 500;
 @listMargin: 0 0 10px 0;
-@listPadding: 0 40px;
 


### PR DESCRIPTION
This commit removes the explicit padding setting `@listPadding: 0 40px;` to adopt the default value of @listPadding defined in variable.less as `@listPadding: 0 25px;`