### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/notes-service/pom.xml
+++ b/notes-service/pom.xml
@@ -34,7 +34,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Notes addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.41</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.43</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/notes-service/src/main/java/io/meeds/notes/legacy/api/search/SearchServiceConnector.java
+++ b/notes-service/src/main/java/io/meeds/notes/legacy/api/search/SearchServiceConnector.java
@@ -1,6 +1,6 @@
 package io.meeds.notes.legacy.api.search;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.container.component.BaseComponentPlugin;
 import org.exoplatform.container.xml.InitParams;

--- a/notes-service/src/main/java/io/meeds/notes/legacy/search/es/ElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/io/meeds/notes/legacy/search/es/ElasticSearchServiceConnector.java
@@ -21,7 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/notes-service/src/main/java/io/meeds/notes/service/NotePageViewService.java
+++ b/notes-service/src/main/java/io/meeds/notes/service/NotePageViewService.java
@@ -20,7 +20,7 @@ package io.meeds.notes.service;
 
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.portal.pom.data.PageKey;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
@@ -19,8 +19,8 @@
 
 package org.exoplatform.wiki.jpa;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.file.model.FileInfo;
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.file.services.FileService;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
@@ -25,7 +25,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.file.services.FileService;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/DraftPageDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/DraftPageDAO.java
@@ -19,8 +19,8 @@ package org.exoplatform.wiki.jpa.dao;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.wiki.jpa.entity.DraftPageEntity;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 import java.util.List;
 
 /**

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/EmotionIconDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/EmotionIconDAO.java
@@ -19,8 +19,8 @@ package org.exoplatform.wiki.jpa.dao;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wiki.jpa.entity.EmotionIconEntity;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 
 public class EmotionIconDAO extends WikiBaseDAO<EmotionIconEntity, Long> {
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/PageDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/PageDAO.java
@@ -21,8 +21,8 @@ package org.exoplatform.wiki.jpa.dao;
 
 import java.util.List;
 
-import javax.persistence.NonUniqueResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NonUniqueResultException;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.wiki.jpa.entity.PageEntity;
 import org.exoplatform.wiki.model.WikiType;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/PageMoveDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/PageMoveDAO.java
@@ -21,7 +21,7 @@ package org.exoplatform.wiki.jpa.dao;
 import org.exoplatform.wiki.jpa.entity.PageMoveEntity;
 import org.exoplatform.wiki.model.WikiType;
 
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 import java.util.List;
 
 public class PageMoveDAO extends WikiBaseDAO<PageMoveEntity,Long> {

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/PageVersionDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/PageVersionDAO.java
@@ -20,9 +20,9 @@ import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.wiki.jpa.entity.PageEntity;
 import org.exoplatform.wiki.jpa.entity.PageVersionEntity;
 
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import java.util.Collections;
 import java.util.List;
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/TemplateDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/TemplateDAO.java
@@ -18,8 +18,8 @@ package org.exoplatform.wiki.jpa.dao;
 
 import org.exoplatform.wiki.jpa.entity.TemplateEntity;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 import java.util.List;
 
 public class TemplateDAO extends WikiBaseDAO<TemplateEntity, Long> {

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/WikiDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/WikiDAO.java
@@ -21,8 +21,8 @@ package org.exoplatform.wiki.jpa.dao;
 
 import java.util.List;
 
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 
 import org.exoplatform.wiki.jpa.entity.WikiEntity;
 import org.exoplatform.wiki.model.WikiType;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/AttachmentEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/AttachmentEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 /**

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/BasePageEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/BasePageEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 /**

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/DraftPageAttachmentEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/DraftPageAttachmentEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * Created by The eXo Platform SAS

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/DraftPageEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/DraftPageEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 /**

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/EmotionIconEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/EmotionIconEntity.java
@@ -2,7 +2,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity(name = "WikiEmotionIconEntity")
 @ExoEntity

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageAttachmentEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageAttachmentEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * Created by The eXo Platform SAS

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageEntity.java
@@ -21,7 +21,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageMoveEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageMoveEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 import java.util.List;
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageVersionEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PageVersionEntity.java
@@ -21,7 +21,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * Created by The eXo Platform SAS

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PermissionEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/PermissionEntity.java
@@ -19,10 +19,10 @@
 
 package org.exoplatform.wiki.jpa.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 import org.exoplatform.wiki.model.PermissionType;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/TemplateEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/TemplateEntity.java
@@ -21,7 +21,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * Created by The eXo Platform SAS

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/WikiEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/WikiEntity.java
@@ -18,7 +18,7 @@ package org.exoplatform.wiki.jpa.entity;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 /**

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/NoteVersionLanguageIndexingServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/NoteVersionLanguageIndexingServiceConnector.java
@@ -19,7 +19,7 @@
 
 package org.exoplatform.wiki.jpa.search;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.search.domain.Document;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.text.Normalizer;
 import java.util.*;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.wiki.utils.Utils;
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiPageIndexingServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiPageIndexingServiceConnector.java
@@ -19,7 +19,7 @@
 
 package org.exoplatform.wiki.jpa.search;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.search.domain.Document;
 import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
 import org.exoplatform.commons.utils.CommonsUtils;

--- a/notes-service/src/main/java/org/exoplatform/wiki/rendering/cache/MarkupData.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/rendering/cache/MarkupData.java
@@ -16,7 +16,7 @@
  */
 package org.exoplatform.wiki.rendering.cache;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class MarkupData implements CacheData<String> {
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/ExportThread.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/ExportThread.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NotesAutoImportService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NotesAutoImportService.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -28,8 +28,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import lombok.SneakyThrows;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.api.EntityNotFoundException;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -28,8 +28,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.gatein.api.EntityNotFoundException;
 import org.json.simple.JSONArray;

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/JsonNodeData.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/JsonNodeData.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import lombok.Data;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.wiki.model.DraftPage;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.tree.utils.TreeUtils;

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/TreeNode.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/TreeNode.java
@@ -19,7 +19,7 @@
 
 package org.exoplatform.wiki.tree;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.comparators.NaturalComparator;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.Wiki;

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
@@ -22,7 +22,7 @@ package org.exoplatform.wiki.tree.utils;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.container.ExoContainerContext;

--- a/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -21,7 +21,7 @@ package org.exoplatform.wiki.utils;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.HashedMap;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.diff.DiffResult;
 import org.exoplatform.commons.diff.DiffService;
 import org.exoplatform.commons.utils.CommonsUtils;

--- a/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
+++ b/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
@@ -510,6 +510,8 @@
   <changeSet id="1.0.0-42" author="wiki">
     <validCheckSum>7:7d4a990e4664c19155e9beb35e6e8ebc</validCheckSum>
     <validCheckSum>7:21d239448c33f39a9300ea433349d470</validCheckSum>
+    <validCheckSum>8:5e8e466efcb51beb7d15b30774a0038c</validCheckSum>
+    <validCheckSum>8:52596a538221249a0e8ac976cfa0d6dc</validCheckSum>
     <sql dbms="mssql">
       IF EXISTS(SELECT * FROM sys.objects WHERE type='D' AND NAME='DF_WIKI_PAGE_ATTACHMENTS_UPDATED_DATE')
         ALTER TABLE WIKI_PAGE_ATTACHMENTS
@@ -528,6 +530,8 @@
   <changeSet id="1.0.0-43" author="wiki">
     <validCheckSum>7:44cfbff48ff23a305643392177e0c79a</validCheckSum>
     <validCheckSum>7:ab5aad25946a4f22c88996951806ccfe</validCheckSum>
+    <validCheckSum>8:4fb0d683e4840475d1078bd36743a512</validCheckSum>
+    <validCheckSum>8:52596a538221249a0e8ac976cfa0d6dc</validCheckSum>
     <sql dbms="mssql">
       IF EXISTS(SELECT * FROM sys.objects WHERE type='D' AND NAME='DF_WIKI_DRAFT_ATTACHMENTS_UPDATED_DATE')
         ALTER TABLE WIKI_DRAFT_ATTACHMENTS

--- a/notes-service/src/test/java/org/exoplatform/wiki/jpa/JPADataStorageTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/jpa/JPADataStorageTest.java
@@ -23,8 +23,8 @@ import java.util.*;
 import org.exoplatform.wiki.model.*;
 import org.mockito.Mockito;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import org.exoplatform.container.PortalContainer;

--- a/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/notes-social-integration/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.log.ExoLogger;


### PR DESCRIPTION
This change will upgrade from Commons Lang to Apache Lang 3, to Jakarta Persistence API 3.1 and will recompute the score of Tests coverage after excluding globally the POJOs from computation scopre computing. ( see Meeds-io/maven-parent-pom#45 )

(Resolves Meeds-io/MIPs#57)