### PR TITLE
fix: Fix scrolling issue in the single note view application edit mode - EXO-68518_68519 - Meeds-io/notes#917

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/inline-config.js
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/inline-config.js
@@ -54,6 +54,8 @@ CKEDITOR.editorConfig = function (config) {
 
   config.autoGrow_onStartup = true;
   config.autoGrow_minHeight = 165;
+  config.autoGrow_maxHeight =  800;
+
   config.height = 165;
   config.format_tags = 'p;h1;h2;h3';
 };


### PR DESCRIPTION
Prior to this change, scrolling when editing in the single note view application  was not functioning as expected. This commit adds configuration option `autoGrow_maxHeight` to improve scrolling functionality.

(cherry picked from commit 6570da4468e8dffde00f94bced240190ba2020dc)