### PR TITLE
fix: Disallow image inserting from desktop dragging and pasting in the single note view application - EXO-68249

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NoteRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NoteRichEditor.vue
@@ -117,6 +117,8 @@ export default {
           enterMode: CKEDITOR.ENTER_P,
           shiftEnterMode: CKEDITOR.ENTER_BR,
           copyFormatting_allowedContexts: true,
+          isImagePasteBlocked: true,
+          hideUploadImageLink: true,
           indentBlock: {
             offset: 40,
             unit: 'px'

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NoteRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NoteRichEditor.vue
@@ -119,6 +119,7 @@ export default {
           copyFormatting_allowedContexts: true,
           isImagePasteBlocked: true,
           hideUploadImageLink: true,
+          isImageDragBlocked: true,
           indentBlock: {
             offset: 40,
             unit: 'px'

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -720,6 +720,7 @@ export default {
         colorButton_enableMore: true,
         isImagePasteBlocked: this.webPageNote,
         hideUploadImageLink: this.webPageNote,
+        isImageDragBlocked: this.webPageNote,
         sharedSpaces: {
           top: 'notesTop'
         },

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -718,6 +718,8 @@ export default {
         bodyClass: 'notesContent',
         dialog_noConfirmCancel: true,
         colorButton_enableMore: true,
+        isImagePasteBlocked: this.webPageNote,
+        hideUploadImageLink: this.webPageNote,
         sharedSpaces: {
           top: 'notesTop'
         },


### PR DESCRIPTION
Prior to this change we were able to insert/paste/drag images from the desktop in the single note view application , this change is going to disallow image inserting/pasting/dragging from the desktop in the single note view application.