### PR TITLE
fix: Fix Note Page Link Display in Achievements - MEED-3126 - Meeds-io/meeds#1489

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
+++ b/notes-webapp/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
@@ -1,3 +1,11 @@
+import * as notesService from '../../javascript/eXo/wiki/notesService.js';
+
+if (!Vue.prototype.$notesService) {
+  window.Object.defineProperty(Vue.prototype, '$notesService', {
+    value: notesService,
+  });
+}
+
 export function init() {
   extensionRegistry.registerExtension('engagementCenterActions', 'user-actions', {
     type: 'note',


### PR DESCRIPTION
Prior to this change, the Note Page Link wasn't displayed in Achivements Drawer and Page. This was due to missing `$notesService` injection in page due to changed FavoriteDrawer which is made lazy loaded.

(Resolves Meeds-io/meeds#1489)