### PR TITLE
fix: Fix Note Page Link Display in Achievements - MEED-3126 - Meeds-io/meeds#1489 (#923)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
+++ b/notes-webapp/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
@@ -1,3 +1,11 @@
+import * as notesService from '../../javascript/eXo/wiki/notesService.js';
+
+if (!Vue.prototype.$notesService) {
+  window.Object.defineProperty(Vue.prototype, '$notesService', {
+    value: notesService,
+  });
+}
+
 export function init() {
   extensionRegistry.registerExtension('engagementCenterActions', 'user-actions', {
     type: 'note',


### PR DESCRIPTION
Prior to this change, the Note Page Link wasn't displayed in Achivements Drawer and Page. This was due to missing `$notesService` injection in page due to changed FavoriteDrawer which is made lazy loaded.

(Resolves Meeds-io/meeds#1489)

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
