### PR TITLE
fix: fix Opening a note from Unified search opens the home page of the plateform - EXO-68332

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1372,7 +1372,7 @@ public class NotesRestService implements ResourceContainer {
                                                         searchResult.getLang(),
                                                         currentIdentity);
         if (page != null) {
-          page.setUrl(searchResult.getUrl());
+          page.setUrl(searchResult.getUrl() != null && !searchResult.getUrl().isBlank() ? searchResult.getUrl() : page.getUrl() + "?translation="+ searchResult.getLang());
           if (SearchResultType.ATTACHMENT.equals(searchResult.getType())) {
             Attachment attachment = noteBookService.getAttachmentOfPageByName(searchResult.getAttachmentName(),
                             page);

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -364,6 +364,7 @@ public class NotesRestServiceTest extends AbstractKernelTest {
     page.setId("100");
     page.setActivityId("12");
     page.setLang("en");
+    page.setUrl("/space/note/100");
     when(noteService.getNoteOfNoteBookByName(searchResult.getWikiType(),
                                              searchResult.getWikiOwner(),
                                              searchResult.getPageName(),


### PR DESCRIPTION
before this change, for old created notes the note URL was not indexed causing when computing the search data into the note to have a null URL
After this change, when computing data we check if the URL is blank, and in this case, we use the original page URL concatenated with the current lang