### PR TITLE
fix: Add Missing I18N file in translation.properties - MEED-3172 - Meeds-io/meeds#1538

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -28,6 +28,7 @@ webapp/webui.properties=notes-webapp/src/main/resources/locale/portal/webui_en.p
 webapp/WikiPortlet.properties=notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
 webapp/NotesPortlet.properties=notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
 webapp/Portlet.properties=notes-webapp/src/main/resources/locale/portlet/Portlets_en.properties
+webapp/NotePageView.properties=notes-webapp/src/main/resources/locale/portlet/NotePageView_en.properties
 
 # portal
 portal/global.properties=notes-webapp/src/main/resources/locale/navigation/portal/global_en.properties


### PR DESCRIPTION
Prior to this change, the file  wasn't added in Crowdin synchronization job. This change introduces it.