### PR TITLE
fix: Add Branding Stylesheet in CKEditor iframe - MEED-3188 - Meeds-io/meeds#1547

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/config.js
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/config.js
@@ -7,7 +7,9 @@ CKEDITOR.editorConfig = function (config) {
 
   // style inside the editor
   config.contentsCss = [];
-  document.querySelectorAll('[skin-type=portal-skin]').forEach(link => config.contentsCss.push(link.href));
+  document.querySelectorAll('[skin-type=portal-skin]')
+    .forEach(link => config.contentsCss.push(link.href));
+  config.contentsCss.push(document.querySelector('#brandingSkin').href);
   config.contentsCss.push('/notes/ckeditorCustom/contents.css'); // load last
 
   const urlParams = new URLSearchParams(window.location.search);

--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/inline-config.js
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/inline-config.js
@@ -7,7 +7,9 @@ CKEDITOR.editorConfig = function (config) {
 
   // style inside the editor
   config.contentsCss = [];
-  document.querySelectorAll('[skin-type=portal-skin]').forEach(link => config.contentsCss.push(link.href));
+  document.querySelectorAll('[skin-type=portal-skin]')
+    .forEach(link => config.contentsCss.push(link.href));
+  config.contentsCss.push(document.querySelector('#brandingSkin').href);
   config.contentsCss.push('/notes/ckeditorCustom/contents.css'); // load last
 
   CKEDITOR.plugins.addExternal('insertOptions','/notes/javascript/eXo/wiki/ckeditor/plugins/insertOptions/','plugin.js');


### PR DESCRIPTION
Prior to this change, the branding style wasn't loaded in extended CKEditor configuration. This change will add the Brnding Stylesheet in CKEditor context of notes and SNV.