### PR TITLE
fix: Prevent the auto import of the knowledge base space if it already exist - EXO-69419

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NotesAutoImportService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NotesAutoImportService.java
@@ -193,8 +193,8 @@ public class NotesAutoImportService implements Startable {
                            String spaceDescription,
                            String zipPath,
                            Identity superUserIdentity) {
-
-    Space space = spaceService.getSpaceByPrettyName(spaceName);
+    String groupId  = "/spaces/" + spaceName;
+    Space space = spaceService.getSpaceByGroupId(groupId);
     if (space == null) {
       space = createSpace(spaceName, spaceDisplayName, spaceDescription, SPACE_TEMPLATE, superUserIdentity);
     }

--- a/notes-service/src/main/resources/conf/portal/configuration.xml
+++ b/notes-service/src/main/resources/conf/portal/configuration.xml
@@ -90,7 +90,7 @@
       </value-param>
       <value-param>
         <name>frKnowledgeBaseSpaceName</name>
-        <value>${exo.notes.knowledge.base.fr.space.nam:exo_knowledge_base_fr}</value>
+        <value>${exo.notes.knowledge.base.fr.space.name:exo_knowledge_base_fr}</value>
       </value-param>
       <value-param>
         <name>enKnowledgeBaseSpaceDispalyName</name>


### PR DESCRIPTION

Prior to this change after renaming one of the knowledge base space and restart the server , the knowledge base space would be recreated , this issue arose due to the space's pretty name being issued to check it's existence , which was changed by renaming the space , This change is going to check the space's existence using the space group id resolving this issue .
