### PR TITLE
feat: Define load-group for Notes and NotesEditor portlets - EXO-65108 - Meeds-io/meeds#1735

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -47,6 +47,7 @@
   <portlet>
     <name>Notes</name>
     <module>
+      <load-group>NotesGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/javascript/notes.bundle.js</path>
@@ -85,6 +86,7 @@
   <portlet>
     <name>NotesEditor</name>
     <module>
+      <load-group>NotesEditorGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/javascript/notesEditor.bundle.js</path>

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/main.js
@@ -24,5 +24,5 @@ export function init() {
         vuetify: Vue.prototype.vuetifyOptions,
         i18n
       }, `#${appId}`, 'Notes Editor Dashboard');
-    });
+    }).finally(() => Vue.prototype.$utils.includeExtensions('NotesEditorExtension'));
 }

--- a/notes-webapp/src/main/webapp/vue-app/notes/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes/main.js
@@ -46,5 +46,5 @@ export function init() {
       vuetify,
       i18n
     }, appElement, 'Notes Overview');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('NotesExtension'));
 }


### PR DESCRIPTION
Prior to this change, we can not extend easily Notes and NotesEditor portlets from other modules. We need to define appropriate load groups for the portlets Notes and NotesEditor in order to easily extend them.