### PR TITLE
fix: add statistics collection for Noes editor page - EXO-70178 - Meeds-io/meeds#1751

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/dynamic-container-configuration.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/dynamic-container-configuration.xml
@@ -163,5 +163,52 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>addPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
+      <description></description>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <value>5</value>
+        </value-param>
+        <value-param>
+          <name>containerName</name>
+          <value>top-notes-editor-container</value>
+        </value-param>
+        <object-param>
+          <name>statistics-portlet</name>
+          <description></description>
+          <object type="org.exoplatform.commons.addons.PortletModel">
+            <field name="contentId">
+              <string>analytics/StatisticsCollection</string>
+            </field>
+            <field name="permissions">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>*:/platform/users</string>
+                </value>
+                <value>
+                  <string>*:/platform/externals</string>
+                </value>
+              </collection>
+            </field>
+            <field name="title">
+              <string>Statistics Collection Portlet</string>
+            </field>
+            <field name="showInfoBar">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationState">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationMode">
+              <boolean>false</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>


### PR DESCRIPTION
This fix will introduce the Statistics Collection Portlet to enable correct initiation of the statistics for Analytics by adding it to the **top-notes-editor-container**
