### PR TITLE
feat: Collapse option should not be applicable to activity notes - MEED-4539 - Meeds-io/MIPS#124

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-activity-stream-extension/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes-activity-stream-extension/main.js
@@ -5,6 +5,7 @@ extensionRegistry.registerExtension('activity', 'type', {
     canEdit: () => false,
     supportsThumbnail: true,
     useSameViewForMobile: true,
+    isCollapsed: false,
     thumbnailProperties: {
       height: '90px',
       width: '90px',


### PR DESCRIPTION
This PR allows to add a new option the the notes activity type extension to check if it is collapsed or not.