### PR TITLE
fix: Notes add/update options are missing in mobile view - EXO-71192 - Meeds-io/meeds#1879 .

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -21,7 +21,7 @@
               class="notes-header-icons text-right">
               <div
                 class="d-inline-flex">
-                <v-tooltip bottom v-if="!isMobile && !hasDraft && isManager">
+                <v-tooltip bottom v-if="!hasDraft && isManager">
                   <template #activator="{ on, attrs }">
                     <v-btn
                       v-on="on"
@@ -41,7 +41,7 @@
               </div>
               <div
                 class="d-inline-flex">
-                <v-tooltip bottom v-if="isManager && !isMobile">
+                <v-tooltip bottom v-if="isManager">
                   <template #activator="{ on, attrs }">
                     <v-btn
                       icon


### PR DESCRIPTION
Before this change, when use responsive view on 6.5.x version and go any space Notes application, Notes add/edit options are not displayed. After this change, Notes add/edit options are on mobile view.
