### PR TITLE
feat: Reuse API to hide widget when empty - MEED-6202 - Meeds-io/MIPs#120

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -106,11 +106,7 @@ export default {
       }
     },
     canView() {
-      if (this.canView) {
-        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
-      } else {
-        this.$el.parentElement.closest('.PORTLET-FRAGMENT').classList.add('hidden');
-      }
+      this.$root.$updateApplicationVisibility(this.canView);
     }
   },
   created() {


### PR DESCRIPTION
This change will reuse a new API to hide widget instead of manipulating DOM in the application.