### PR TITLE
fix: Notes creation/update title hidden - EXO-71328 - Meeds-io/meeds#1909

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -70,7 +70,6 @@
       overflow: auto;
       z-index: 5;
       background-color: #eeeeee;
-      margin-top: 102px;
 
       .notes-content-form {
         min-height: calc(~"100vh - 140px");
@@ -104,7 +103,6 @@
       width: 100%;
       z-index: 10;
       background-color: @baseBackground;
-      position: absolute;
 
       .notesActions {
         .notesFormButtons {


### PR DESCRIPTION
Before this change, when on mobile view create /update note, title is hidden by ckeditor. After this change, Title is displayed and can be filled / updated.

(cherry picked from commit 80982c116f1fd0b06ebb2b12f2b25ab1faf8ccf3)