### PR TITLE
fix: Delete orphan draft pages when the space is deleted - EXO-70385 - Meeds-io/MIPs#119

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
@@ -1559,4 +1559,12 @@ public class JPADataStorage implements DataStorage {
     pageEntity.setVersions(history);
     pageDAO.update(pageEntity);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void deleteOrphanDraftPagesByParentPage(long parentPageId) {
+    draftPageDAO.deleteOrphanDraftPagesByParentPage(parentPageId);
+  }
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/DraftPageDAO.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/dao/DraftPageDAO.java
@@ -21,6 +21,7 @@ package org.exoplatform.wiki.jpa.dao;
 
 import java.util.List;
 
+import jakarta.persistence.Query;
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.wiki.jpa.entity.DraftPageEntity;
 
@@ -87,6 +88,13 @@ public class DraftPageDAO extends WikiBaseDAO<DraftPageEntity, Long> {
     } catch (NoResultException e) {
       return null;
     }
+  }
+
+  @ExoTransactional
+  public void deleteOrphanDraftPagesByParentPage(long parentPageId) {
+    Query query = getEntityManager().createNamedQuery("wikiDraftPage.deleteOrphanDraftPagesByParentPage");
+    query.setParameter("id", parentPageId);
+    query.executeUpdate();
   }
 
   public DraftPageEntity findLatestDraftPageByTargetPageAndLang(Long targetPageId, String lang) {

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/DraftPageEntity.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/entity/DraftPageEntity.java
@@ -53,7 +53,8 @@ import jakarta.persistence.Table;
         @NamedQuery(name = "wikiDraftPage.findDraftPageByTargetPage", query = "SELECT d FROM WikiDraftPageEntity d WHERE d.targetPage.id = :targetPageId"),
         @NamedQuery(name = "wikiDraftPage.findDraftPagesByParentPage", query = "SELECT d FROM WikiDraftPageEntity d WHERE d.parentPage.id = :parentPageId"),
         @NamedQuery(name = "wikiDraftPage.findLatestDraftPageByTargetPageAndLang", query = "SELECT d FROM WikiDraftPageEntity d WHERE d.targetPage.id = :targetPageId AND " +
-                                                                                                  "((:lang IS NULL AND d.lang IS NULL) OR (:lang IS NOT NULL AND d.lang = :lang)) ORDER BY d.updatedDate DESC"), })
+                                                                                                  "((:lang IS NULL AND d.lang IS NULL) OR (:lang IS NOT NULL AND d.lang = :lang)) ORDER BY d.updatedDate DESC"),
+        @NamedQuery(name = "wikiDraftPage.deleteOrphanDraftPagesByParentPage", query = "DELETE FROM WikiDraftPageEntity d WHERE d.targetPage IS NULL AND d.parentPage.id=:id")})
 public class DraftPageEntity extends BasePageEntity {
 
   @Id

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/organization/WikiGroupEventListener.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/organization/WikiGroupEventListener.java
@@ -24,6 +24,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.GroupEventListener;
+import org.exoplatform.wiki.jpa.EntityConverter;
 import org.exoplatform.wiki.jpa.dao.PageDAO;
 import org.exoplatform.wiki.jpa.dao.TemplateDAO;
 import org.exoplatform.wiki.jpa.dao.WikiDAO;
@@ -32,6 +33,7 @@ import org.exoplatform.wiki.jpa.entity.TemplateEntity;
 import org.exoplatform.wiki.jpa.entity.WikiEntity;
 import org.exoplatform.wiki.jpa.search.WikiPageIndexingServiceConnector;
 import org.exoplatform.wiki.model.WikiType;
+import org.exoplatform.wiki.service.NoteService;
 
 import java.util.List;
 
@@ -49,12 +51,15 @@ public class WikiGroupEventListener extends GroupEventListener {
   private PageDAO pageDAO;
   private TemplateDAO templateDAO;
   private IndexingService indexingService;
+  private NoteService noteService;
 
-  public WikiGroupEventListener(WikiDAO wikiDAO, PageDAO pageDAO, TemplateDAO templateDAO, IndexingService indexingService) {
+  public WikiGroupEventListener(WikiDAO wikiDAO, PageDAO pageDAO, TemplateDAO templateDAO, IndexingService indexingService,
+                                NoteService noteService) {
     this.wikiDAO = wikiDAO;
     this.pageDAO = pageDAO;
     this.templateDAO = templateDAO;
     this.indexingService = indexingService;
+    this.noteService = noteService;
   }
 
   @Override
@@ -68,6 +73,8 @@ public class WikiGroupEventListener extends GroupEventListener {
     if (pages != null) {
       for (PageEntity page : pages) {
         indexingService.unindex(WikiPageIndexingServiceConnector.TYPE, String.valueOf(page.getId()));
+        noteService.removeDraftOfNote(EntityConverter.convertPageEntityToPage(page));
+        noteService.removeOrphanDraftPagesByParentPage(page.getId());
       }
       pageDAO.deleteAll(pages);
     }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/DataStorage.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/DataStorage.java
@@ -264,4 +264,10 @@ public interface DataStorage {
    */
   void deleteVersionsByNoteIdAndLang(Long noteId, String lang) throws WikiException;
 
+  /**
+   * Remove all children drafts of a parent page without existing target
+   *
+   * @param parentPageId Note parent page id
+   */
+  void deleteOrphanDraftPagesByParentPage(long parentPageId);
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
@@ -755,4 +755,12 @@ public interface NoteService {
   @Deprecated
   // Use {@link deleteVersionsByNoteIdAndLang(Long noteId, String lang)} instead
   void deleteVersionsByNoteIdAndLang(Long noteId, String username, String lang) throws WikiException;
+
+
+  /**
+   * Remove all children drafts of a parent page without existing target
+   *
+   * @param parentPageId Note parent page id
+   */
+  void removeOrphanDraftPagesByParentPage(long parentPageId);
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1754,4 +1754,12 @@ public class NoteServiceImpl implements NoteService {
                  });
     return metadata;
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void removeOrphanDraftPagesByParentPage(long parentPageId) {
+    dataStorage.deleteOrphanDraftPagesByParentPage(parentPageId);
+  }
 }

--- a/notes-service/src/test/java/org/exoplatform/wiki/jpa/JPADataStorageTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/jpa/JPADataStorageTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.wiki.jpa.entity.DraftPageEntity;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -51,6 +52,8 @@ import org.exoplatform.wiki.model.Wiki;
 import org.exoplatform.wiki.service.IDType;
 import org.exoplatform.wiki.service.WikiPageParams;
 import org.exoplatform.wiki.utils.NoteConstants;
+
+import static org.exoplatform.social.core.jpa.test.AbstractCoreTest.persist;
 
 /**
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com
@@ -1140,6 +1143,26 @@ public class JPADataStorageTest extends BaseWikiJPAIntegrationTest {
     assertTrue(step2Watchers.contains("user2"));
     assertEquals(1, step3Watchers.size());
     assertTrue(step3Watchers.contains("user2"));
+  }
+
+  public void testDeleteOrphanDraftPagesByParentPage() throws Exception {
+    Wiki wiki = new Wiki();
+    wiki.setType("portal");
+    wiki.setOwner("root");
+    wiki = storage.createWiki(wiki);
+    PageEntity homePage = pageDAO.find(Long.valueOf(wiki.getWikiHome().getId()));
+    DraftPageEntity draft = new DraftPageEntity();
+    draft.setParentPage(homePage);
+    draft.setName("orphanDraft");
+    draft.setTargetPage(null);
+    draft.setCreatedDate(new Date());
+    draft.setUpdatedDate(new Date());
+
+    draft = draftPageDAO.create(draft);
+    assertNotNull(draft);
+    storage.deleteOrphanDraftPagesByParentPage(Long.parseLong(wiki.getWikiHome().getId()));
+    persist();
+    assertNull(draftPageDAO.find(draft.getId()));
   }
 
   protected void startSessionAs(String user) {

--- a/notes-service/src/test/java/org/exoplatform/wiki/jpa/dao/DraftPageDAOTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/jpa/dao/DraftPageDAOTest.java
@@ -30,6 +30,8 @@ import org.exoplatform.wiki.jpa.entity.DraftPageEntity;
 import org.exoplatform.wiki.jpa.entity.PageEntity;
 import org.exoplatform.wiki.jpa.entity.WikiEntity;
 
+import static org.exoplatform.social.core.jpa.test.AbstractCoreTest.persist;
+
 /**
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com Jun
  * 26, 2015
@@ -346,6 +348,7 @@ public class DraftPageDAOTest extends BaseWikiJPAIntegrationTest {
     dp1.setCreatedDate(new Date());
     dp1.setUpdatedDate(new Date());
     draftPageDAO.create(dp1);
+    persist();
     DraftPageEntity dp2 = new DraftPageEntity();
     dp2.setName("draft2");
     dp2.setTargetPage(page);

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
@@ -21,6 +21,7 @@
 package org.exoplatform.wiki.service;
 
 
+import static org.exoplatform.social.core.jpa.test.AbstractCoreTest.persist;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -683,5 +684,19 @@ public class TestNoteService extends BaseTest {
     note.setContent("english content");
     noteService.createVersionOfNote(note, user.getUserId());
     assertNotNull(noteService.getPublishedVersionByPageIdAndLang(Long.valueOf(note.getId()), "en"));
+  }
+
+  public void testRemoveOrphanDraftPagesByParentPage() throws Exception {
+    startSessionAs("root");
+    Wiki portalWiki = getOrCreateWiki(wService, PortalConfig.GROUP_TYPE, "/platform/users");
+    Page homePage = noteService.getNoteById(portalWiki.getWikiHome().getId());
+    DraftPage draft = new DraftPage();
+    draft.setParentPageId(homePage.getId());
+    draft.setTargetPageId(null);
+    draft = noteService.createDraftForNewPage(draft, new Date().getTime());
+    assertNotNull(draft);
+    noteService.removeOrphanDraftPagesByParentPage(Long.parseLong(homePage.getId()));
+    persist();
+    assertNull(noteService.getDraftNoteById(draft.getId(), "root"));
   }
 }


### PR DESCRIPTION
Prior to this change, when deleting a note space, the related space note data is not well deleted when the space have orphan drafts (for non existing pages) which raises an exception related to the constraint foreign key violation when attempting to delete note pages with children orphan drafts.
This PR makes sure to delete all note drafts before proceeding to delete the related note pages.
