### PR TITLE
feal: Display last comments on notes activity - MEED-4546 - Meeds-io/MIPs#124

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-activity-stream-extension/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes-activity-stream-extension/main.js
@@ -1,3 +1,5 @@
+const activityTypeExtensions = extensionRegistry.loadExtensions('activity', 'type');
+const defaultActivityOptions = activityTypeExtensions.find(extension => extension.type === 'default').options;
 extensionRegistry.registerExtension('activity', 'type', {
   type: 'ks-wiki:spaces',
   options: {
@@ -29,6 +31,7 @@ extensionRegistry.registerExtension('activity', 'type', {
       }
       return '#';
     },
+    displayLastCommentsRequiredActions: defaultActivityOptions.displayLastCommentsRequiredActions,
     canShare: () => true,
   },
 });


### PR DESCRIPTION
This PR allows to add notes actions type to the list of required actions to display the last two comments in activity.