### PR TITLE
fix: Fix add translation in sub note when no translation connector active - EXO-71327 - Meeds-io/meeds#1987

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -496,8 +496,11 @@ export default {
         if ((this.note.content.trim().length === 0)) {
           const noteId = !this.note.draftPage ? this.note.id : this.note.targetPageId;
           this.$notesService.getNoteById(noteId,this.selectedLanguage,'','','',true)
-            .then(data => {
-              if (data && data.children && data.children.length) {
+            .then(note => {
+              if (this.selectedLanguage && !note?.lang) {
+                return;
+              }
+              if (note?.children?.length) {
                 this.updateNoteContent(childContainer);
                 this.setFocus();
               }
@@ -1063,7 +1066,7 @@ export default {
       document.dispatchEvent(new CustomEvent('translation-added',{ detail: originNoteContent }));
     },
     updateNoteTitle(title) {
-      this.note.title=title;
+      this.note.title = title;
     },
     updateNoteContent(content) {
       this.note.content = content;


### PR DESCRIPTION
prior to this change, issue when adding translation in sub note when no translation connector active because of the default returned note when no translation exists for requested language. 
This PR fixes the issue by adding a check to make sure that we have requested for a specific lang version note and that wasn't exists.