### PR TITLE
feat: Allow to choose page to redirect from SNV full Editor - MEED-6937 - Meeds-io/meeds#2060

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
@@ -127,7 +127,7 @@ export default {
       formData.append('showMaxWindow', 'true');
       formData.append('hideSharedLayout', 'true');
       formData.append('webPageNote', 'true');
-      formData.append('webPageUrl', `${window.location.pathname}${window.location.search || ''}`);
+      formData.append('webPageUrl', eXo?.env?.portal?.webPageUrl || `${window.location.pathname}${window.location.search || ''}`);
       if (this.note?.lang) {
         formData.append('translation', this.note.lang);
       }


### PR DESCRIPTION
This change will allow to specify a page URI to redirect to when the user publishes the Notes using Full Note Editor page.
(Resolves https://github.com/Meeds-io/meeds/issues/2060)