### PR TITLE
fix: Navigation menu not displayed if text added in the body of a note - EXO-71919 - Meeds-io/meeds#2067 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -388,6 +388,9 @@ export default {
                 });
               },
               methods: {
+                getNoteLanguages(noteId) {
+                  return this.$root.$children[0].getNoteLanguages(noteId);
+                },
                 getNodeById(noteId, source, noteBookType, noteBookOwner) {
                   return this.$notesService.getNoteById(noteId,this.selectedTranslation.value, source, noteBookType, noteBookOwner).then(data => {
                     this.note = data || {};


### PR DESCRIPTION
Navigation menu not displayed if text added in the body of a note
fixes #985 