### PR TITLE
fix: No Image properties option in editor context menu - EXO-72349 - Meeds-io/meeds#2142

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -731,8 +731,6 @@ export default {
           instanceReady: function (evt) {
             self.editor = evt.editor;
             self.actualNote.content = self.editor.getData();
-            self.editor.removeMenuItem('linkItem');
-            self.editor.removeMenuItem('selectImageItem');
             $(self.editor.document.$)
               .find('.atwho-inserted')
               .each(function() {


### PR DESCRIPTION
Restore the Image properties option in the editor contextmenu
