### PR TITLE
fix: Fix Font Style of Rich Editor Based Content - MEED-7132 - Meeds-io/MIPs#144

### DIFF
--- a/notes-webapp/src/main/webapp/ckeditor/skins/common/custom-variables.less
+++ b/notes-webapp/src/main/webapp/ckeditor/skins/common/custom-variables.less
@@ -14,13 +14,11 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-@normalFontSize: 16px;
 @bodyMargin: 19px;
 @blockquoteFontStyle: normal;
 @blockquoteMargin: 0 0 10px 0;
 @blockquotePadding: 10px;
 @ckEditableFontSize: 14px;
 @ckEditableLineHeight: 1.4;
-@titleFontWeight: 500;
 @listMargin: 0 0 10px 0;
 


### PR DESCRIPTION
This change will delete specialization of Font size in Notes to rely on the one defined in Platform-UI which has been made 'brandable' from page layout properties and application properties drawer.