### PR TITLE
feat: Make notes portal skin module accessible from any platform page - EXO-72970 - Meeds-io/MIPs#128

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -20,7 +20,6 @@
     <skin-name>Enterprise</skin-name>
     <skin-module>Notes</skin-module>
     <css-path>/skin/css/notes/notes.css</css-path>
-    <filtered>true</filtered>
   </portal-skin>
 
   <portlet-skin>


### PR DESCRIPTION
Prior to this change, after unifying content editor with notes editor, the css of notes is not loaded for the content editor due to the filtered param declared for Notes skin module. In order to make notes css accessible from any page of the platform, we need to remove this param.