### PR TITLE
Fix: Notes - import note generate new folder in doc app while it has to be located under the root of the space instead of under the Documents folder- EXO-71883 - Meeds-io/meeds#2315 (#1066)

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1482,7 +1482,7 @@ public class NoteServiceImpl implements NoteService {
     if (parent_ == null) {
       parent_ = wiki.getWikiHome();
     }
-    String imagesSubLocationPath = "Documents/notes/images";
+    String imagesSubLocationPath = "notes/images";
     Page note_ = note;
     if (!NoteConstants.NOTE_HOME_NAME.equals(note.getName())) {
       note.setId(null);


### PR DESCRIPTION
Before this commit when the user exports and imports notes, images are stored under /documents/notes/images so they are available in the doc app for all space members. This commit changes the images location under the root folder so space members will not be able to see them

(cherry picked from commit f3624d6cb3ec9c648dd90ef9e0d018173fb98ac1)