### PR TITLE
FIX: Notes tags - click on tags on home page displays no results - EXO-73907

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -61,9 +61,7 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
   private static final Log           LOG                          = ExoLogger.getLogger(WikiElasticSearchServiceConnector.class);
 
   private static final String        SEARCH_QUERY_FILE_PATH_PARAM = "query.file.path";
-
   private final IdentityManager      identityManager;
-
   private final ConfigurationManager configurationManager;
 
   private String                     searchQuery;
@@ -278,8 +276,8 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
       wikiSearchResult.setUrl(url);
       wikiSearchResult.setScore(score);
 
-      if (wikiOwner != null && wikiOwner.startsWith("/spaces/")) {
-        String wikiOwnerPrettyName = wikiOwner.split("/spaces/")[1];
+      if (wikiOwner != null && wikiOwner.startsWith("spaces/")) {
+        String wikiOwnerPrettyName = wikiOwner.split("spaces/")[1];
         Identity wikiOwnerIdentity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, wikiOwnerPrettyName, true);
         wikiSearchResult.setWikiOwnerIdentity(wikiOwnerIdentity);
       }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -53,6 +53,9 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.wiki.model.*;
 import org.gatein.api.EntityNotFoundException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -74,11 +77,6 @@ import org.exoplatform.social.rest.entity.IdentityEntity;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.wiki.WikiException;
-import org.exoplatform.wiki.model.Attachment;
-import org.exoplatform.wiki.model.DraftPage;
-import org.exoplatform.wiki.model.Page;
-import org.exoplatform.wiki.model.Wiki;
-import org.exoplatform.wiki.model.WikiType;
 import org.exoplatform.wiki.resolver.TitleResolver;
 import org.exoplatform.wiki.service.NoteService;
 import org.exoplatform.wiki.service.NotesExportService;
@@ -124,6 +122,8 @@ public class NotesRestService implements ResourceContainer {
 
   private final UploadService         uploadService;
 
+  private final IdentityManager identityManager;
+
   private final ResourceBundleService resourceBundleService;
 
   private final CacheControl          cc;
@@ -131,12 +131,14 @@ public class NotesRestService implements ResourceContainer {
   public NotesRestService(NoteService noteService,
                           WikiService noteBookService,
                           UploadService uploadService,
+                          IdentityManager identityManager,
                           ResourceBundleService resourceBundleService,
                           NotesExportService notesExportService) {
     this.noteService = noteService;
     this.noteBookService = noteBookService;
     this.notesExportService = notesExportService;
     this.uploadService = uploadService;
+    this.identityManager = identityManager;
     this.resourceBundleService = resourceBundleService;
     cc = new CacheControl();
     cc.setNoCache(true);
@@ -1413,8 +1415,15 @@ public class NotesRestService implements ResourceContainer {
             titleSearchResult.setMetadatas(page.getMetadatas());
             titleSearchResult.setLang(searchResult.getLang());
             titleSearchResults.add(titleSearchResult);
-          } else if (searchResult.getPoster() != null) {
-            IdentityEntity posterIdentity = EntityBuilder.buildEntityIdentity(searchResult.getPoster(), uriInfo.getPath(), "all");
+          } else if (searchResult.getPoster() != null || searchResult.getPageName().equals(WikiPageParams.WIKI_HOME)) {
+            PageVersion pageVersion = noteService.getPublishedVersionByPageIdAndLang(Long.parseLong(page.getId()), null);
+            org.exoplatform.social.core.identity.model.Identity poster = searchResult.getPoster();
+            if (pageVersion != null) {
+              poster = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, pageVersion.getAuthor());
+            }
+            IdentityEntity posterIdentity =
+                    poster != null ? EntityBuilder.buildEntityIdentity(poster, uriInfo.getPath(), "all")
+                            : null;
             IdentityEntity wikiOwnerIdentity =
                     searchResult.getWikiOwnerIdentity() != null ? EntityBuilder.buildEntityIdentity(searchResult.getWikiOwnerIdentity(),
                             uriInfo.getPath(),
@@ -1424,7 +1433,9 @@ public class NotesRestService implements ResourceContainer {
             titleSearchResult.setTitle(searchResult.getTitle());
             titleSearchResult.setId(page.getId());
             titleSearchResult.setActivityId(page.getActivityId());
-            titleSearchResult.setPoster(posterIdentity);
+            if (posterIdentity != null) {
+              titleSearchResult.setPoster(posterIdentity);
+            }
             titleSearchResult.setWikiOwner(wikiOwnerIdentity);
             titleSearchResult.setExcerpt(searchResult.getExcerpt());
             titleSearchResult.setCreatedDate(searchResult.getCreatedDate().getTimeInMillis());

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
@@ -121,7 +121,7 @@ public class TestWikiRestService extends AbstractKernelTest { // NOSONAR
     entityBuilder.when(() -> EntityBuilder.buildEntityIdentity(nullable(Identity.class), anyString(), anyString()))
                  .thenReturn(entity);
     NotesRestService wikiRestService =
-                                     new NotesRestService(noteService, wikiService, null, new MockResourceBundleService(), null);
+                                     new NotesRestService(noteService, wikiService, null, null, new MockResourceBundleService(), null);
 
     // When
     List<String> tagNames = new ArrayList<>();

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -39,6 +39,8 @@ import java.util.ResourceBundle;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import jakarta.persistence.EntityManager;
+import org.exoplatform.social.core.manager.IdentityManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +92,8 @@ public class NotesRestServiceTest extends AbstractKernelTest {
 
   @Mock
   private UploadService                     uploadService;
-
+  @Mock
+  private IdentityManager identityManager;
   @Mock
   private NotesExportService                notesExportService;
 
@@ -138,6 +141,7 @@ public class NotesRestServiceTest extends AbstractKernelTest {
     this.notesRestService = new NotesRestService(noteService,
                                                  noteBookService,
                                                  uploadService,
+            identityManager,
                                                  resourceBundleService,
                                                  notesExportService);
 


### PR DESCRIPTION
Prior to this fix, search on for home notes doesn't display any note, this is due to that home page don't have poster. This commit we will use the last modifier user in the search result.