### PR TITLE
FIX: Notes tags - click on tags on home page displays no results - EXO-73907

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -280,8 +280,8 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
       wikiSearchResult.setUrl(url);
       wikiSearchResult.setScore(score);
 
-      if (wikiOwner != null && wikiOwner.startsWith("/spaces/")) {
-        String wikiOwnerPrettyName = wikiOwner.split("/spaces/")[1];
+      if (wikiOwner != null && wikiOwner.startsWith("spaces/")) {
+        String wikiOwnerPrettyName = wikiOwner.split("spaces/")[1];
         Identity wikiOwnerIdentity = identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, wikiOwnerPrettyName, true);
         wikiSearchResult.setWikiOwnerIdentity(wikiOwnerIdentity);
       }

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
@@ -121,7 +121,7 @@ public class TestWikiRestService extends AbstractKernelTest { // NOSONAR
     entityBuilder.when(() -> EntityBuilder.buildEntityIdentity(nullable(Identity.class), anyString(), anyString()))
                  .thenReturn(entity);
     NotesRestService wikiRestService =
-                                     new NotesRestService(noteService, wikiService, null, new MockResourceBundleService(), null);
+            new NotesRestService(noteService, wikiService, null, null, new MockResourceBundleService(), null);
 
     // When
     List<String> tagNames = new ArrayList<>();

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.exoplatform.commons.utils.PageList;
+import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.rest.api.EntityBuilder;
 import org.exoplatform.social.rest.api.RestUtils;
 import org.exoplatform.social.rest.entity.IdentityEntity;
@@ -71,6 +72,8 @@ public class NotesRestServiceTest extends AbstractKernelTest {
 
   @Mock
   private UploadService                     uploadService;
+  @Mock
+  private IdentityManager identityManager;
 
   @Mock
   private NotesExportService                notesExportService;
@@ -118,6 +121,7 @@ public class NotesRestServiceTest extends AbstractKernelTest {
     this.notesRestService = new NotesRestService(noteService,
                                                  noteBookService,
                                                  uploadService,
+            identityManager,
                                                  resourceBundleService,
                                                  notesExportService);
 


### PR DESCRIPTION
Prior to this fix, search on for home notes doesn't display any note, this is due to that home page don't have poster. This commit we will use the last modifier user in the search result.