### PR TITLE
fix: Properties of newly created note are not updated - EXO-74190 - Meeds-io/MIPs#128

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -786,7 +786,7 @@ public class NotesRestService implements ResourceContainer {
           noteService.removeDraftOfNote(noteParams, note.getLang());
         }
       } else if ((featuredImage != null && (featuredImage.isToDelete() || featuredImage.getUploadId() != null))
-          || (note_.getProperties() != null && !notePageProperties.getSummary().equals(note_.getProperties().getSummary()))) {
+          || !Objects.equals(note_.getProperties(), notePageProperties)) {
         if (StringUtils.isBlank(note.getLang())) {
           note_.setProperties(notePageProperties);
           note_ = noteService.updateNote(note_, PageUpdateType.EDIT_PAGE_PROPERTIES, identity);


### PR DESCRIPTION
Properties of newly created note are not updated
