### PR TITLE
fix: Ui/ux issues in note create/switch translation - EXO-73222, EXO-74157 - Meeds-io/MIPs#129

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -139,7 +139,7 @@ export default {
                                 && !this.propertiesModified && !this.draftNote) || this.savingDraft;
     },
     noteNotModified() {
-      return this.note?.title === this.originalNote?.title && this.note?.content === this.originalNote?.content;
+      return this.note?.title === this.originalNote?.title && this.$noteUtils.isSameContent(this.note?.content, this.originalNote?.content);
     },
     propertiesModified() {
       return JSON.stringify(this.note?.properties) !== JSON.stringify(this.originalNote?.properties);
@@ -370,6 +370,10 @@ export default {
         return;
       }
 
+      if (!this.note?.title?.length && !this.note?.content?.length) {
+        return;
+      }
+
       // if the Note is not updated, no need to autosave anymore
       if ((this.note?.title === this.actualNote.title) && (this.note?.content === this.actualNote.content)
           && (JSON.stringify(this.note?.properties) === JSON.stringify(this.actualNote?.properties))) {
@@ -411,9 +415,8 @@ export default {
                 this.displayDraftMessage();
               }, this.autoSaveDelay / 2);
               this.initActualNoteDone = true;
-            } else {
-              this.draftNote = latestDraft;
             }
+            this.draftNote = latestDraft;
           } else {
             return this.$notesService.getNoteById(id, lang)
               .then(data => {
@@ -545,7 +548,7 @@ export default {
         }
         if (draftNote.properties) {
           draftNote.properties.draft = true;
-          if (this.newTranslation) {
+          if (this.newTranslation && !this.featuredImageUpdated) {
             draftNote.properties.featuredImage = null;
           }
         }

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -327,6 +327,7 @@ export default {
     resetEditorData() {
       this.noteObject.title = null;
       if (this.noteObject?.properties) {
+        this.noteObject.properties.featuredImage = null;
         this.noteObject.properties.summary = '';
       }
       this.editor.setData('');


### PR DESCRIPTION
Ui/ux issues in note create/switch translation:

- featured image not reset when automatic translation is not available while creating a new translation
- "draft saving..." message remains displayed when adding a new translation while the automatic translation is not available
- switch between translations enables the save button without existing of draft
