### PR TITLE
feat: Update calls to UserACL to avoid implicit usage of Conversation State in Service Layer - MEED-7555 - Meeds-io/MIPs#151

### DIFF
--- a/notes-service/src/test/java/io/meeds/notes/service/NotePageViewServiceTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/service/NotePageViewServiceTest.java
@@ -29,7 +29,6 @@ import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.model.PortalConfig;
-import org.exoplatform.portal.mop.PageType;
 import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.page.PageState;
@@ -161,14 +160,9 @@ public class NotePageViewServiceTest extends BaseTest { // NOSONAR
     PageState pageState = new PageState(pageName,
                                         null,
                                         false,
-                                        false,
                                         null,
                                         Collections.singletonList(accessPermission),
-                                        editPermission,
-                                        Collections.singletonList(editPermission),
-                                        Collections.singletonList(editPermission),
-                                        PageType.PAGE.name(),
-                                        null);
+                                        editPermission);
     layoutService.save(new PageContext(pageKey, pageState));
     return pageKey.format();
   }

--- a/notes-service/src/test/java/org/exoplatform/wiki/mock/MockUserACL.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/mock/MockUserACL.java
@@ -18,17 +18,8 @@ package org.exoplatform.wiki.mock;
 
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.portal.config.UserACL;
-import org.exoplatform.portal.config.model.Page;
 
 public class MockUserACL extends UserACL {
-
-  /* (non-Javadoc)
-   * @see org.exoplatform.portal.config.UserACL#hasPermission(org.exoplatform.portal.config.model.Page)
-   */
-  @Override
-  public boolean hasPermission(Page page) {
-    return true;
-  }
 
   /**
    * @param params


### PR DESCRIPTION
This change will update UserACL usage to not implicitly use the current conversation state of authenticated user.