### PR TITLE
fix: Toc is not displayed in default empty note content - EXO-74504 - Meeds-io/meeds#2450

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -969,7 +969,7 @@ export default {
       this.note.wikiOwner = this.note.wikiOwner.substring(1);
       this.$notesService.getNoteTree(this.note.wikiType, this.note.wikiOwner, this.note.name, 'children').then(data => {
         if (data?.jsonList?.length) {
-          this.noteChildren = data?.jsonList[0]?.children;
+          this.noteChildren = data?.jsonList;
         }
       });
     },


### PR DESCRIPTION
Toc is not displayed in default empty note content
