### PR TITLE
fix: Fix image cropper styles in notes-editor - EXO-74717 - Meeds-io/MIPs#129

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -31,6 +31,7 @@
     <portlet-name>NotesEditor</portlet-name>
     <skin-name>Enterprise</skin-name>
     <additional-module>Notes</additional-module>
+    <additional-module>ImageCropper</additional-module>
   </portlet-skin>
 
   <portlet-skin>


### PR DESCRIPTION
Fix image cropper styles in notes-editor 