### PR TITLE
fix: Fix import featured images - EXO-74718 - Meeds-io/meeds#2499

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 
@@ -1315,7 +1316,8 @@ public class NoteServiceImpl implements NoteService {
           notesFilePath = file;
       }
       if (file.contains("/" + FEATURED_IMAGE_FOLDER + "/")) {
-        String imageId = file.substring(file.lastIndexOf("/") + 1);
+        String fileName = file.substring(file.lastIndexOf("/") + 1);
+        String imageId = fileName.substring(0, fileName.lastIndexOf("."));
         featuredImages.put(imageId, file);
       }
     }
@@ -1938,6 +1940,7 @@ public class NoteServiceImpl implements NoteService {
                           String conflict,
                           Identity userIdentity) throws Exception {
 
+    Page targetNote = null;
     File featuredImageFile = extractNoteFeaturedImageFileToImport(note, featuredImages);
     Page parent_ = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), parent.getName());
     if (parent_ == null) {
@@ -1954,6 +1957,7 @@ public class NoteServiceImpl implements NoteService {
                                                                               imagesSubLocationPath);
         note.setContent(processedContent);
         note_ = createNote(wiki, parent_.getName(), note, userIdentity, false);
+        targetNote = note_;
       } else {
         if (StringUtils.isNotEmpty(conflict)) {
           if (conflict.equals("overwrite") || conflict.equals("replaceAll")) {
@@ -1963,7 +1967,7 @@ public class NoteServiceImpl implements NoteService {
                                                                                   imagesSubLocationPath);
             note.setContent(processedContent);
             note_ = createNote(wiki, parent_.getName(), note, userIdentity, false);
-
+            targetNote = note_;
           }
           if (conflict.equals("duplicate")) {
             String processedContent = htmlUploadImageProcessor.processSpaceImages(note.getContent(),
@@ -1971,9 +1975,11 @@ public class NoteServiceImpl implements NoteService {
                                                                                   imagesSubLocationPath);
             note.setContent(processedContent);
             note_ = createNote(wiki, parent_.getName(), note, userIdentity);
+            targetNote = note_;
           }
           if (conflict.equals("update")) {
-            if (!note_2.getTitle().equals(note.getTitle()) || !note_2.getContent().equals(note.getContent())) {
+            if (!note_2.getTitle().equals(note.getTitle()) || !note_2.getContent().equals(note.getContent())
+                || !Objects.equals(note_2.getProperties(), note.getProperties())) {
               note_2.setTitle(note.getTitle());
               String processedContent = htmlUploadImageProcessor.processSpaceImages(note.getContent(),
                                                                                     wiki.getOwner(),
@@ -1981,6 +1987,7 @@ public class NoteServiceImpl implements NoteService {
               note_2.setContent(processedContent);
               note_2 = updateNote(note_2, PageUpdateType.EDIT_PAGE_CONTENT, userIdentity);
               createVersionOfNote(note_2, userIdentity.getUserId());
+              targetNote = note_2;
             }
           }
         }
@@ -1989,7 +1996,7 @@ public class NoteServiceImpl implements NoteService {
       if (StringUtils.isNotEmpty(conflict)
           && (conflict.equals("update") || conflict.equals("overwrite") || conflict.equals("replaceAll"))) {
         Page note_1 = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), note.getName());
-        if (!note.getContent().equals(note_1.getContent())) {
+        if (!note.getContent().equals(note_1.getContent()) || !Objects.equals(note_1.getProperties(), note.getProperties())) {
           String processedContent = htmlUploadImageProcessor.processSpaceImages(note.getContent(),
                                                                                 wiki.getOwner(),
                                                                                 imagesSubLocationPath);
@@ -1997,12 +2004,13 @@ public class NoteServiceImpl implements NoteService {
           note_1.setContent(processedContent);
           note_1 = updateNote(note_1, PageUpdateType.EDIT_PAGE_CONTENT, userIdentity);
           createVersionOfNote(note_1, userIdentity.getUserId());
+          targetNote = note_1;
         }
       }
     }
     if (featuredImageFile != null) {
       saveImportedFeaturedImage(featuredImageFile,
-                                note,
+                                targetNote,
                                 Long.parseLong(identityManager.getOrCreateUserIdentity(userIdentity.getUserId()).getId()));
     }
     if (note.getChildren() != null) {


### PR DESCRIPTION
Prior to this change, when import notes with featured images, the featured image are not correctly imported due to wrong extraction of featuredId from exported fileName beside a wrong handle of different conflict actions.
This PR makes sure to correctly extract the export featured image id to correctly import featured images.
