### PR TITLE
FIX: Notes_basics actions_task: Move - Forbid to move a note below its children - EXO-74174-Meeds-io/meeds#2513

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteTreeviewDrawer.vue
@@ -707,7 +707,19 @@ export default {
         }
       }
       return itemsArray;
+    },   
+
+    filterItemsForMove(item) {
+      if (item.noteId===this.note.id) {
+        delete item.children;
+        return item;
+      }
+      for (let i = 0; i < item.children.length; i++) {
+        item.children[i] = this.filterItemsForMove(item.children[i]);
+      }
+      return item;
     },
+
     naturalSort(items) {
       if (items?.length) {
         const collator = new Intl.Collator(eXo.env.portal.language, {numeric: true, sensitivity: 'base'});
@@ -732,6 +744,10 @@ export default {
             } else {
               this.mapItems(this.items[0]?.children);
             }
+          } 
+          if (this.movePage) {
+            const home = { children: this.items , noteId: 0};
+            this.filterItemsForMove(home);
           }
           if (this.isDraftFilter) {
             this.naturalSort(this.items);


### PR DESCRIPTION

Prior to this fix, when a user moved a note that had children, he was able to select the children and move the note below them. It creates an infinite loop.
 This commit filters the move treeview to not display children of the current node, so the user will not be able to select any of them as a destination.