### PR TITLE
fix: Preserve Data when duplicating SNV Portlet - MEED-7687 - Meeds-io/MIPs#165

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/plugin/layout/renderer/NoteSingleViewRenderPlugin.java
+++ b/notes-service/src/main/java/io/meeds/notes/plugin/layout/renderer/NoteSingleViewRenderPlugin.java
@@ -52,6 +52,11 @@ public class NoteSingleViewRenderPlugin implements PortletInstancePreferencePlug
 
   @Override
   public List<PortletInstancePreference> generatePreferences(Application application, Portlet preferences) {
+    if (preferences != null && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {
+      return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME,
+                                                                     preferences.getPreference(DATA_INIT_PREFERENCE_NAME)
+                                                                                .getValue()));
+    }
     String settingName = getCmsSettingName(preferences);
     if (StringUtils.isBlank(settingName)) {
       return Collections.emptyList();


### PR DESCRIPTION
Prior to this change, when the SNV Portlet doesn't have been initialized/displayed yet in a page, like the default Space Templates, the 'data.init' preference isn't used to initialize the portlet yet and thus when duplicating the page template, the 'data.init' has to be reused instead of generated only when the CMS portlet is initialized.