### PR TITLE
fix: Unexpected Notes/News bottom white line added on each update - EXO - 75342 - Meeds-io/meeds#2594

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -710,6 +710,7 @@ export default {
         enterMode: CKEDITOR.ENTER_P,
         shiftEnterMode: CKEDITOR.ENTER_BR,
         copyFormatting_allowedContexts: true,
+        autoParagraph: false,
         indentBlock: {
           offset: 40,
           unit: 'px'


### PR DESCRIPTION
Before this change, when edit same notes/news by adding some content and save, on each update, an additional empty line is added. To resolve this problem, add an autoParagraph property of value false in the ckeditor. After this change, no additional empty line is added.

(cherry picked from commit https://github.com/Meeds-io/notes/commit/fa8814235c3b5d812c04ccc524bf8fa7775a4324)