### PR TITLE
fix: Fix featured image is deleted in case of creating new page - EXO-75508 - Meeds-io/meeds#2614

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1711,8 +1711,8 @@ import lombok.SneakyThrows;
     if (isDraft) {
       DraftPage draftPage = getDraftNoteById(String.valueOf(noteId),
                                              identityManager.getIdentity(String.valueOf(userIdentityId)).getRemoteId());
-      if (draftPage != null && draftPage.getTargetPageId() != null
-          && isOriginalFeaturedImage(draftPage, getNoteByIdAndLang(Long.valueOf(draftPage.getTargetPageId()), lang))) {
+      if (draftPage != null && (draftPage.getTargetPageId() == null
+          || isOriginalFeaturedImage(draftPage, getNoteByIdAndLang(Long.valueOf(draftPage.getTargetPageId()), lang)))) {
         removeFeaturedImageFile = false;
       }
       note = draftPage;
@@ -1997,6 +1997,20 @@ import lombok.SneakyThrows;
                   lang,
                   true,
                   Long.parseLong(identityManager.getOrCreateUserIdentity(note.getOwner()).getId()));
+        } else if (note.isDraftPage()) {
+          // When delete a draft of non-existing page
+          // check if its featured image was linked to a saved page
+          List<MetadataItem> metadataItems =
+                                           metadataService.getMetadataItemsByMetadataNameAndTypeAndObjectAndMetadataItemProperty(NOTES_METADATA_TYPE.getName(),
+                                                                                                                                 NOTES_METADATA_TYPE.getName(),
+                                                                                                                                 NOTE_METADATA_PAGE_OBJECT_TYPE,
+                                                                                                                                 FEATURED_IMAGE_ID,
+                                                                                                                                 featuredImageId,
+                                                                                                                                 0,
+                                                                                                                                 0);
+          if (metadataItems == null || metadataItems.isEmpty()) {
+            fileService.deleteFile(Long.parseLong(featuredImageId));
+          }
         } else {
           fileService.deleteFile(Long.parseLong(featuredImageId));
         }


### PR DESCRIPTION
Prior to this change, when create new page from draft with featured image and try to delete the draft after saving the new page, the featured image is deleted with the draft, which should not be the case when the featured image is linked to the original saved page, this due to wrong condition handling on the `removeNoteFeaturedImage` function in case of draft of new page.
Same issue when delete draft, we don't have a check whether its featured image was associated to saved page or not which may cause non expected file deletion.

This PR treats the case by updating the condition to not delete the featured image in case of draft of new page, knowing that in case of delete orphan drafts the featured image deletion is treated out of this function we have updated that case by checking if its linked image was associated to a saved page or not before deleting its related featured Image file.
