### PR TITLE
fix: filter displays only parent notes issue - EXO-75447 - Meeds-io/meeds#2616

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
@@ -149,6 +149,7 @@ public class JPADataStorage implements DataStorage {
                                                                 wikiSearchData.getUserId(),
                                                                 wikiSearchData.getTagNames(),
                                                                 wikiSearchData.isFavorites(),
+                                                                wikiSearchData.isNotesTreeFilter(),
                                                                 (int) wikiSearchData.getOffset(),
                                                                 wikiSearchData.getLimit());
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1260,7 +1260,9 @@ public class NotesRestService implements ResourceContainer {
                                      int limit, @QueryParam("wikiType")
                                      String wikiType, @QueryParam("wikiOwner")
                                      String wikiOwner, @QueryParam("favorites")
-                                     boolean favorites, @QueryParam("tags") List<String> tagNames) throws Exception {
+                                     boolean favorites, @QueryParam("tags")
+                                     List<String> tagNames, @QueryParam("isNotesTreeFilter")
+                                     boolean isNotesTreeFilter) throws Exception {
     limit = limit > 0 ? limit : RestUtils.getLimit(uriInfo);
     try {
 
@@ -1268,6 +1270,7 @@ public class NotesRestService implements ResourceContainer {
       Identity currentIdentity = ConversationState.getCurrent().getIdentity();
       WikiSearchData data = new WikiSearchData(keyword, currentIdentity.getUserId());
       data.setLimit(limit);
+      data.setNotesTreeFilter(isNotesTreeFilter);
       data.setFavorites(favorites);
       data.setTagNames(tagNames);
       List<SearchResult> results = noteService.search(data).getAll();
@@ -1286,6 +1289,7 @@ public class NotesRestService implements ResourceContainer {
             TitleSearchResult titleSearchResult = new TitleSearchResult();
             titleSearchResult.setTitle(attachment.getName());
             titleSearchResult.setId(page.getId());
+            titleSearchResult.setPageName(page.getName());
             titleSearchResult.setActivityId(page.getActivityId());
             titleSearchResult.setType(searchResult.getType());
             titleSearchResult.setUrl(attachment.getDownloadURL());
@@ -1309,6 +1313,8 @@ public class NotesRestService implements ResourceContainer {
             TitleSearchResult titleSearchResult = new TitleSearchResult();
             titleSearchResult.setTitle(searchResult.getTitle());
             titleSearchResult.setId(page.getId());
+            titleSearchResult.setPageName(page.getName());
+            titleSearchResult.setPageName(page.getName());
             titleSearchResult.setActivityId(page.getActivityId());
             if (posterIdentity != null) {
               titleSearchResult.setPoster(posterIdentity);

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/search/SearchData.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/search/SearchData.java
@@ -47,6 +47,8 @@ public class SearchData {
 
   private List<String> tagNames;
 
+  private boolean isNotesTreeFilter;
+
   public SearchData(String title, String content, String wikiType, String wikiOwner, String pageId, String userId) {
     this.title = org.exoplatform.wiki.utils.Utils.escapeIllegalCharacterInQuery(title);
     this.content = org.exoplatform.wiki.utils.Utils.escapeIllegalCharacterInQuery(content);

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/search/TitleSearchResult.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/search/TitleSearchResult.java
@@ -49,4 +49,6 @@ public class TitleSearchResult {
 
   private String                          lang;
 
+  private String                          pageName;
+
 }

--- a/notes-service/src/test/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnectorTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnectorTest.java
@@ -144,7 +144,7 @@ public class WikiElasticSearchServiceConnectorTest extends AbstractKernelTest {
     // when
     List<String> tagNames = new ArrayList<>();
     tagNames.add("testNoteTag");
-    List<SearchResult> searchResults = searchServiceConnector.searchWiki("*","__system", tagNames, false, 0, 20);
+    List<SearchResult> searchResults = searchServiceConnector.searchWiki("*","__system", tagNames, false, false, 0, 20);
 
     // Then
     assertNotNull(searchResults);

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
@@ -126,7 +126,7 @@ public class TestWikiRestService extends AbstractKernelTest { // NOSONAR
     // When
     List<String> tagNames = new ArrayList<>();
     tagNames.add("testTag");
-    Response response = wikiRestService.searchData(uriInfo, "wiki", 10, "page", "alioua", false, tagNames);
+    Response response = wikiRestService.searchData(uriInfo, "wiki", 10, "page", "alioua", false, tagNames, false);
 
     // Then
     assertEquals(200, response.getStatus());

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -445,7 +445,7 @@ public class NotesRestServiceTest extends AbstractKernelTest {
                                                                 anyString()))
                   .thenReturn(identityEntity);
 
-    Response response = notesRestService.searchData(uriInfo, "test", 10, "wikiType", "wikiOwner", true, new ArrayList<>());
+    Response response = notesRestService.searchData(uriInfo, "test", 10, "wikiType", "wikiOwner", true, new ArrayList<>(), false);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 

--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
@@ -1,7 +1,7 @@
 import { notesConstants } from './notesConstants.js';
 
 export function getNote(noteBookType, noteBookOwner, noteId,source,lang) {
-  let url = `${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/note/${noteBookType}/${noteBookOwner}/${noteId}`;
+let url = `${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/note/${noteBookType}/${noteBookOwner}/${noteId}`;
   if (source){
     url=`${url}?source=${source}`;
   }
@@ -441,4 +441,18 @@ export function removeNoteFeaturedImage(noteId, isDraft, lang) {
       throw new Error('Error when deleting note featured image');
     }
   });
+}
+
+export function searchNotes(keyword, limit) {
+  document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
+  return fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/contextsearch?keyword=${keyword}&isNotesTreeFilter=true&limit=${limit}`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Response code indicates a server error', resp);
+    } else {
+      return resp.json();
+    }
+  }).finally(() => document.dispatchEvent(new CustomEvent('hideTopBarLoading')));
 }


### PR DESCRIPTION
Before this change, when open drawer of note filter and serach for a sub-level note, only first level parent notes are displayed and sub-level notes are never displayed. To resolve this problem, consume the rest of the unified search filter service for the published notes and for the draft filter using the list already retrieved. After this change, Sub-level notes is displayed in notes filter search results.

(cherry picked from commit 874de42562bd9799ca122b9e2c8edc971fc29293)