### PR TITLE
fix: fix translation version featured image save when remove its related draft - EXO-75639 - Meeds-io/meeds#2623

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1489,6 +1489,7 @@ import lombok.SneakyThrows;
       page.setTitle(publishedVersion.getTitle());
       page.setContent(publishedVersion.getContent());
       page.setLang(publishedVersion.getLang());
+      page.setProperties(publishedVersion.getProperties());
       page.setLatestVersionId(publishedVersion.getId());
     }
     return page;


### PR DESCRIPTION
Prior to this change, when saving a translation version of a note with featured image, the image is not saved because of the wrong properties returned by `getNoteByIdAndLang` which returns the properties of the original note and not the published version, which caused an issue in the `DeleteDraftById` while checking the possibility of deleting the file if it's already linked or not.
This PR fixes the issue by correcting the returned properties when calling `getNoteByIdAndLang`.

