### PR TITLE
Fix: fix unable to save snv translation - EXO-75758 - Meeds-io/meeds#2642

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -137,10 +137,11 @@ export default {
   },
   computed: {
     saveOrUpdateDisabled() {
-      return (!this.note?.title || this.note?.title?.length < 3
-                                || this.note?.title?.length > this.titleMaxLength)
-                                || (this.noteNotModified
+      return this.notValidTitle || (this.noteNotModified
                                 && !this.propertiesModified && !this.draftNote && !this.note.draftPage) || this.savingDraft;
+    },
+    notValidTitle() {
+      return !this.webPageNote && (!this.note?.title || this.note?.title?.length < 3 || this.note?.title?.length > this.titleMaxLength);
     },
     noteNotModified() {
       return this.note?.title === this.originalNote?.title && this.$noteUtils.isSameContent(this.note?.content, this.originalNote?.content);


### PR DESCRIPTION
prior to this change, when editing an snv with advanced edition option and adding a translation while automatic translation is disabled, the save button remains disabled as it checks the validity of the note title in the snv while it shouldn't in this case which causes the non validation of the from to enable the save. 
This PR ensures to ignore validating the title in an snv case to fix thus issue.