### PR TITLE
fix: labels are not translated in publication drawer - EXO-75965 - meeds-io/MIPS#161

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-publication/components/NotePublicationDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-publication/components/NotePublicationDrawer.vue
@@ -298,6 +298,14 @@ export default {
       }
     }
   },
+  created() {
+    const lang = eXo.env.portal.language;
+    const urls = `/content/i18n/locale.portlet.notes.notesPortlet?lang=${lang}`;
+
+    exoi18n.loadLanguageAsync(lang, urls)
+      .then(() => this.$nextTick())
+      .finally(() => this.loading = false);
+  },
   methods: {
     updateAdvancedSettings(settings) {
       this.advancedSettings = structuredClone(settings);


### PR DESCRIPTION
Before this fix, the i18n file for noptespublicationDrawer is not loaded when the drawer is opened from the news detail. This commit add the load of the needed file on drawer creation

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
