### PR TITLE
fix: Fix refresh the whole page and just focus on note editor body when pressing enter on note editor title - EXO-73109 - Meeds-io/meeds#2742

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -57,7 +57,8 @@
                 type="text"
                 :maxlength="noteTitleMaxLength + 1"
                 class="title text-color ma-0 pa-0"
-                @input="waitUserTyping()">
+                @input="waitUserTyping()"
+                @keydown.enter.prevent="focusEditor">
             </div>
             <div class="formInputGroup white overflow-auto flex notes-content-wrapper px-5 pb-5">
               <textarea
@@ -330,6 +331,9 @@ export default {
     },
     hideTranslationsBar() {
       this.$root.$emit('hide-translations');
+    },
+    focusEditor() {
+      this.editor.focus();
     },
     setEditorData(content) {
       if (content) {


### PR DESCRIPTION
Prior to this change when pressing enter on note editor title, the whole page is refreshed, the title is reseted and an error message is displayed when I write something. After this change, we ensure to not refresh anymore the whole page and that my cursor is focused on the note body.

Resolves https://github.com/Meeds-io/meeds/issues/2742