### PR TITLE
fix: Fix publication drawer save button enabled when publish option enabled without selected targets - EXO-76163 - Meeds-io/meeds#2743

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-publication/components/NotePublicationDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-publication/components/NotePublicationDrawer.vue
@@ -250,7 +250,7 @@ export default {
       return this.canSchedule && (!this.editMode || (this.publicationSettings?.publish || !!this.noteObject?.schedulePostDate));
     },
     saveEnabled() {
-      return (!this.editMode || this.publicationSettingsUpdated) && (this.canPublish && this.validPublishSettings || true);
+      return (!this.editMode || this.publicationSettingsUpdated) && (this.canPublish && this.validPublishSettings);
     },
     validPublishSettings() {
       return !this.publicationSettings?.publish || (this.publicationSettings?.publish && this.publicationSettings?.selectedTargets?.length);


### PR DESCRIPTION
Prior to this change, it is possible to publish or edit publish an article when publish option is enabled without selected targets. After this commit, we ensure to disable publication drawer save/publish button when the publish option is enabled with no selected targets.

Resolves https://github.com/Meeds-io/meeds/issues/2743