### PR TITLE
fix: Refine note creation and update logic with indexing control - EXO-75010 - Meeds-io/meeds#2752

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
@@ -62,6 +62,18 @@ public interface NoteService {
    * Create a new note in the given notebook, under the given parent note.
    *
    * @param noteBook Notebook object.
+   * @param parentNote parent note.
+   * @param note the note to create.
+   * @param broadcast broadcast the note creation event
+   * @return The new note.
+   * @throws WikiException if an error occured
+   */
+  Page createNote(Wiki noteBook, Page parentNote, Page note, boolean broadcast) throws WikiException;
+
+  /**
+   * Create a new note in the given notebook, under the given parent note.
+   *
+   * @param noteBook Notebook object.
    * @param parentNoteName parent note name.
    * @param note the note object to create.
    * @param userIdentity user Identity.
@@ -72,7 +84,7 @@ public interface NoteService {
    */
   Page createNote(Wiki noteBook, String parentNoteName, Page note, Identity userIdentity) throws WikiException,
                                                                                           IllegalAccessException;
-  
+
   /**
    * Create a new note in the given notebook, under the given parent note.
    *
@@ -80,14 +92,33 @@ public interface NoteService {
    * @param parentNoteName parent note name.
    * @param note the note object to create.
    * @param userIdentity user Identity.
-   * @param importMode true if the creation is without timestamp for import mode. 
+   * @param importMode true if the creation is without timestamp for import mode.
+   * @param broadcast broadcast the note creation event if true
    * @return The new note.
    * @throws WikiException if an error occured
    * @throws IllegalAccessException if the user don't have edit rights to the
    *           parent note
    */
-  Page createNote(Wiki noteBook, String parentNoteName, Page note, Identity userIdentity, boolean importMode) throws WikiException,
+  Page createNote(Wiki noteBook, String parentNoteName, Page note, Identity userIdentity, boolean importMode, boolean broadcast) throws WikiException,
                                                                                           IllegalAccessException;
+  /**
+   * Create a new note in the given notebook, under the given parent note.
+   *
+   * @param noteBook Notebook object.
+   * @param parentNoteName parent note name.
+   * @param note the note object to create.
+   * @param userIdentity user Identity.
+   * @param broadcast broadcast the note creation event if true.
+   * @return The new note.
+   * @throws WikiException if an error occured
+   * @throws IllegalAccessException if the user don't have edit rights to the
+   *           parent note
+   */
+  Page createNote(Wiki noteBook,
+                  String parentNoteName,
+                  Page note,
+                  Identity userIdentity,
+                  boolean broadcast) throws WikiException, IllegalAccessException;
 
   /**
    * Deletes a note.
@@ -499,10 +530,25 @@ public interface NoteService {
    *           note
    * @throws EntityNotFoundException if the the note to update don't exist
    */
-  Page updateNote(Page note, PageUpdateType type, Identity userIdentity) throws WikiException,
-                                                                         IllegalAccessException,
-                                                                         EntityNotFoundException,
-                                                                         Exception;
+  Page updateNote(Page note, PageUpdateType type, Identity userIdentity) throws Exception;
+
+  /**
+   * Update the given note. This does not automatically create a new version. If
+   * a new version must be created it should be explicitly done by calling
+   * createVersionOfNote(). The second parameter is the type of update done
+   * (title only, content only, both, move, ...).
+   *
+   * @param note Updated note
+   * @param type Type of update
+   * @param userIdentity user Identity
+   * @param broadcast broadcast the update note event if true
+   * @return The updated note
+   * @throws WikiException if an error occure
+   * @throws IllegalAccessException if the user don't have edit rights on the
+   *           note
+   * @throws EntityNotFoundException if the the note to update don't exist
+   */
+  Page updateNote(Page note, PageUpdateType type, Identity userIdentity, boolean broadcast) throws Exception;
 
   /**
    * Update the given note. This does not automatically create a new version. If

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -66,7 +66,6 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.thumbnail.ImageThumbnailService;
-import org.exoplatform.social.common.service.HTMLUploadImageProcessor;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
@@ -230,7 +229,8 @@ import lombok.SneakyThrows;
                          String parentNoteName,
                          Page note,
                          Identity userIdentity,
-                         boolean importMode) throws WikiException, IllegalAccessException {
+                         boolean importMode,
+                         boolean broadcast) throws WikiException, IllegalAccessException {
     if (importMode) {
       String pageName = TitleResolver.getId(note.getName(), false);
       if (pageName == null) {
@@ -248,7 +248,7 @@ import lombok.SneakyThrows;
       note.setOwner(userIdentity.getUserId());
       note.setAuthor(userIdentity.getUserId());
       note.setContent(note.getContent());
-      Page createdPage = createNote(noteBook, parentPage, note);
+      Page createdPage = createNote(noteBook, parentPage, note, broadcast);
       NotePageProperties properties = note.getProperties();
       String draftPageId = properties != null && properties.isDraft() ? String.valueOf(properties.getNoteId()) : null;
       try {
@@ -302,11 +302,28 @@ import lombok.SneakyThrows;
     return createNote(noteBook, parentNoteName, note, userIdentity, true);
   }
 
+  @Override
+  public Page createNote(Wiki noteBook,
+                         String parentNoteName,
+                         Page note,
+                         Identity userIdentity,
+                         boolean broadcast) throws WikiException, IllegalAccessException {
+    return createNote(noteBook, parentNoteName, note, userIdentity, true, broadcast);
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public Page createNote(Wiki noteBook, Page parentPage, Page note) throws WikiException {
+    return createNote(noteBook, parentPage, note, true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Page createNote(Wiki noteBook, Page parentPage, Page note, boolean broadcast) throws WikiException {
     Page createdPage = dataStorage.createPage(noteBook, parentPage, note);
     createdPage.setToBePublished(note.isToBePublished());
     createdPage.setToBePublished(note.isToBePublished());
@@ -319,7 +336,9 @@ import lombok.SneakyThrows;
     invalidateCache(note);
 
     Utils.broadcast(listenerService, "note.posted", note.getAuthor(), createdPage);
-    postAddPage(noteBook.getType(), noteBook.getOwner(), note.getName(), createdPage);
+    if (broadcast) {
+      postAddPage(noteBook.getType(), noteBook.getOwner(), note.getName(), createdPage);
+    }
     Matcher mentionMatcher = Utils.MENTION_PATTERN.matcher(createdPage.getContent());
     if (mentionMatcher.find()) {
       Utils.sendMentionInNoteNotification(createdPage, null, createdPage.getAuthor());
@@ -341,6 +360,14 @@ import lombok.SneakyThrows;
    */
   @Override
   public Page updateNote(Page note, PageUpdateType type, Identity userIdentity) throws Exception {
+    return updateNote(note, type, userIdentity, true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Page updateNote(Page note, PageUpdateType type, Identity userIdentity, boolean broadcast) throws Exception {
     Page existingNote = getNoteById(note.getId());
     if (existingNote == null) {
       throw new EntityNotFoundException("Note to update not found");
@@ -384,14 +411,17 @@ import lombok.SneakyThrows;
 
     Matcher mentionsMatcher = Utils.MENTION_PATTERN.matcher(note.getContent());
     if (mentionsMatcher.find()) {
-      Utils.sendMentionInNoteNotification(note, existingNote, userIdentity != null ? userIdentity.getUserId() : existingNote.getAuthor());
+      Utils.sendMentionInNoteNotification(note,
+                                          existingNote,
+                                          userIdentity != null ? userIdentity.getUserId() : existingNote.getAuthor());
     }
     Utils.broadcast(listenerService, "note.updated", note.getAuthor(), updatedPage);
-    postUpdatePage(updatedPage.getWikiType(), updatedPage.getWikiOwner(), updatedPage.getName(), updatedPage, type);
+    if (broadcast) {
+      postUpdatePage(updatedPage.getWikiType(), updatedPage.getWikiOwner(), updatedPage.getName(), updatedPage, type);
+    }
     updatedPage.setLang(note.getLang());
     return updatedPage;
   }
-
   /**
    * {@inheritDoc}
    */
@@ -2003,23 +2033,22 @@ import lombok.SneakyThrows;
     if (parent_ == null) {
       parent_ = wiki.getWikiHome();
     }
-    String imagesSubLocationPath = "notes/images";
     Page note_ = note;
     if (!NoteConstants.NOTE_HOME_NAME.equals(note.getName())) {
       note.setId(null);
       Page note_2 = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), note.getName());
       if (note_2 == null) {
-        note_ = createNote(wiki, parent_.getName(), note, userIdentity, false);
+        note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, false);
         targetNote = note_;
       } else {
         if (StringUtils.isNotEmpty(conflict)) {
           if (conflict.equals("overwrite") || conflict.equals("replaceAll")) {
             deleteNote(wiki.getType(), wiki.getOwner(), note.getName());
-            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false);
+            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, false);
             targetNote = note_;
           }
           if (conflict.equals("duplicate")) {
-            note_ = createNote(wiki, parent_.getName(), note, userIdentity);
+            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, false);
             targetNote = note_;
           }
           if (conflict.equals("update")) {


### PR DESCRIPTION
Prior to this change, the note creation and update indexing behavior was not controlled. This change refines the note creation and update logic by introducing a broadcast parameter to control the indexing behavior.