### PR TITLE
feat: Clone SNV Image Attachments when initialized from data - MEED-8109 - Meeds-io/meeds#2775

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/plugin/WikiDraftPageAttachmentPlugin.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/plugin/WikiDraftPageAttachmentPlugin.java
@@ -21,63 +21,62 @@ package org.exoplatform.wiki.service.plugin;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.attachment.AttachmentPlugin;
-import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.wiki.model.DraftPage;
 import org.exoplatform.wiki.service.NoteService;
 import org.exoplatform.wiki.utils.Utils;
 
-public class WikiDraftPageAttachmentPlugin  extends AttachmentPlugin {
+public class WikiDraftPageAttachmentPlugin extends AttachmentPlugin {
 
-    private final NoteService noteService;
+  public static final String OBJECT_TYPE = "wikiDraft";
 
-    private final SpaceService spaceService;
+  private final NoteService  noteService;
 
-    public static final String OBJECT_TYPE = "wikiDraft";
+  private final SpaceService spaceService;
 
-    public WikiDraftPageAttachmentPlugin(NoteService noteService, SpaceService spaceService) {
-        this.noteService = noteService;
-        this.spaceService = spaceService;
+  public WikiDraftPageAttachmentPlugin(NoteService noteService, SpaceService spaceService) {
+    this.noteService = noteService;
+    this.spaceService = spaceService;
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean hasAccessPermission(Identity identity, String draftId) {
+    try {
+      DraftPage draftPage = noteService.getDraftNoteById(draftId, identity.getUserId());
+      return draftPage != null && draftPage.isCanView();
+    } catch (Exception e) {
+      return false;
     }
+  }
 
-    @Override
-    public String getObjectType() {
-        return OBJECT_TYPE;
+  @Override
+  public boolean hasEditPermission(Identity identity, String draftId) throws ObjectNotFoundException {
+    try {
+      DraftPage draftPage = noteService.getDraftNoteById(draftId, identity.getUserId());
+      return draftPage != null && draftPage.isCanManage();
+    } catch (Exception e) {
+      return false;
     }
+  }
 
-    @Override
-    public boolean hasAccessPermission(Identity identity, String draftId) {
-        try {
-            DraftPage draftPage = noteService.getDraftNoteById(draftId, identity.getUserId());
-            return draftPage != null && draftPage.isCanView();
-        } catch (Exception e) {
-            return false;
-        }
-    }
+  @Override
+  public long getAudienceId(String s) throws ObjectNotFoundException {
+    return 0;
+  }
 
-    @Override
-    public boolean hasEditPermission(Identity identity, String draftId) throws ObjectNotFoundException {
-        try {
-            DraftPage draftPage = noteService.getDraftNoteById(draftId, identity.getUserId());
-            return draftPage != null && draftPage.isCanManage();
-        } catch (Exception e) {
-            return false;
-        }
+  @Override
+  public long getSpaceId(String draftId) throws ObjectNotFoundException {
+    try {
+      String username = Utils.getCurrentUser();
+      DraftPage draftPage = noteService.getDraftNoteById(draftId, username);
+      return Long.parseLong(spaceService.getSpaceByGroupId(draftPage.getWikiOwner()).getId());
+    } catch (Exception exception) {
+      return 0;
     }
-
-    @Override
-    public long getAudienceId(String s) throws ObjectNotFoundException {
-        return 0;
-    }
-
-    @Override
-    public long getSpaceId(String draftId) throws ObjectNotFoundException {
-        try {
-            String username = Utils.getCurrentUser();
-            DraftPage draftPage = noteService.getDraftNoteById(draftId, username);
-            return Long.parseLong(spaceService.getSpaceByGroupId(draftPage.getWikiOwner()).getId());
-        } catch (Exception exception) {
-            return 0;
-        }
-    }
+  }
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/plugin/WikiPageAttachmentPlugin.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/plugin/WikiPageAttachmentPlugin.java
@@ -27,54 +27,54 @@ import org.exoplatform.wiki.service.NoteService;
 
 public class WikiPageAttachmentPlugin extends AttachmentPlugin {
 
-    private final NoteService noteService;
+  public static final String OBJECT_TYPE = "wikiPage";
 
-    private final SpaceService spaceService;
+  private final NoteService  noteService;
 
-    public static final String OBJECT_TYPE = "wikiPage";
+  private final SpaceService spaceService;
 
-    public WikiPageAttachmentPlugin(NoteService noteService, SpaceService spaceService) {
-        this.noteService = noteService;
-        this.spaceService = spaceService;
+  public WikiPageAttachmentPlugin(NoteService noteService, SpaceService spaceService) {
+    this.noteService = noteService;
+    this.spaceService = spaceService;
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean hasAccessPermission(Identity identity, String noteId) {
+    try {
+      Page note = noteService.getNoteById(noteId, identity);
+      return note != null && note.isCanView();
+    } catch (Exception e) {
+      return false;
     }
+  }
 
-    @Override
-    public String getObjectType() {
-        return OBJECT_TYPE;
+  @Override
+  public boolean hasEditPermission(Identity identity, String noteId) throws ObjectNotFoundException {
+    try {
+      Page note = noteService.getNoteById(noteId, identity);
+      return note != null && note.isCanManage();
+    } catch (Exception e) {
+      return false;
     }
+  }
 
-    @Override
-    public boolean hasAccessPermission(Identity identity, String noteId) {
-        try {
-            Page note = noteService.getNoteById(noteId, identity);
-            return note != null && note.isCanView();
-        } catch (Exception e) {
-            return false;
-        }
-    }
+  @Override
+  public long getAudienceId(String s) throws ObjectNotFoundException {
+    return 0;
+  }
 
-    @Override
-    public boolean hasEditPermission(Identity identity, String noteId) throws ObjectNotFoundException {
-        try {
-            Page note = noteService.getNoteById(noteId, identity);
-            return note != null && note.isCanManage();
-        } catch (Exception e) {
-            return false;
-        }
+  @Override
+  public long getSpaceId(String noteId) throws ObjectNotFoundException {
+    try {
+      Page note = noteService.getNoteById(noteId);
+      return Long.parseLong(spaceService.getSpaceByGroupId(note.getWikiOwner()).getId());
+    } catch (Exception exception) {
+      return 0;
     }
-
-    @Override
-    public long getAudienceId(String s) throws ObjectNotFoundException {
-        return 0;
-    }
-
-    @Override
-    public long getSpaceId(String noteId) throws ObjectNotFoundException {
-        try {
-            Page note = noteService.getNoteById(noteId);
-            return Long.parseLong(spaceService.getSpaceByGroupId(note.getWikiOwner()).getId());
-        } catch (Exception exception) {
-            return 0;
-        }
-    }
+  }
 }


### PR DESCRIPTION
This change will allow to clone an SNV attachmenet from an originating SNV in order to apply ACL using new SNV Page Access Permissions rather than old SNV Page Access Permissions.

Resolves https://github.com/Meeds-io/meeds/issues/2775