### PR TITLE
FIX: Print to pdf includes the menu - EXO-76492 - Meeds-io/meeds#2783

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -54,7 +54,7 @@
               cols="6">
               <div
                 id="note-actions-menu"
-                v-show="loadData && !hideElementsForSavingPDF"
+                v-if="loadData && !hideElementsForSavingPDF"
                 class="notes-header-icons text-right d-flex justify-end">
                 <div
                   class="d-inline-flex">


### PR DESCRIPTION
Prior to this fix, Pdf created from notes includes the notes menu. This commit adds a timeout to wait until the menu is closed before creating the pdf content.