### PR TITLE
fix: WYSIWYG issue - no margin in quick edit - EXO-76499 - Meeds-io/meeds#2734.

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -236,6 +236,11 @@
   margin-bottom: 0px !important;
 }
 
+.notesRichEditorContent {
+  margin-right: 20px !important;
+  margin-left: 20px !important;
+}
+
 #notesOverviewApplication {
 
   .notes-application-content {

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NoteRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NoteRichEditor.vue
@@ -125,7 +125,7 @@ export default {
             unit: 'px'
           },
           format_tags: 'p;h1;h2;h3',
-          bodyClass: 'notesContent',
+          bodyClass: 'notesContent notesRichEditorContent',
           dialog_noConfirmCancel: true,
           pasteFilter: 'p; a[!href]; strong; i', 
           on: {


### PR DESCRIPTION
Before this change, when add a SNV to a page and edit the SNV in quick edit, the margin in quick edit is no longer present. The text is next to the edge of the SNV. To resolve this problem, add a margin to the left and right of 20px. After this change, the content is fully displayed as it's in the edit mode.
