### PR TITLE
fix: a text with a link on all the text is not fully displayed - EXO-76498 - Meeds-io/meeds#2735

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageView.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageView.vue
@@ -26,7 +26,7 @@
       indeterminate />
     <div
       v-else
-      v-sanitized-html="pageContent"
+      v-html="sanitizedPageContent"
       class="reset-style-box rich-editor-content extended-rich-content overflow-hidden full-width"></div>
   </div>
 </template>
@@ -34,8 +34,14 @@
 <script>
 export default {
   computed: {
-    pageContent() {
-      return this.$root.pageContent && this.$noteUtils.getContentToDisplay(this.$root.pageContent) || '';
+    sanitizedPageContent() {
+      const DOMPurify = require('dompurify');
+      const pageContent = this.$root.pageContent && this.$noteUtils.getContentToDisplay(this.$root.pageContent) || '';
+      const sanitizedContent = DOMPurify.sanitize(pageContent, {
+        tagNameCheck: () => true,
+        attributeNameCheck: () => true,
+      });
+      return sanitizedContent;
     },
   },
 };


### PR DESCRIPTION
Before this change, when create a SNV with a quite long text (more than 6 lines) then select all the text and add a link on it and save the SNV, The text is displayed only one line with an ellipsis. To resolve this problem, replace v-sanitized-html with v-html because v-sanitized-html is automatically ellipsised for sanitized using DOMPurify. After this change, the text is fully displayed as it's in the edit mode.

(cherry picked from commit b91bdc267395ff24b8ce56ab1e689cef8dc72c56)