### PR TITLE
fix: Fix space members can not create articles - MEED-8322 - Meeds-io/meeds#2858

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-publication/components/NotePublicationDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-publication/components/NotePublicationDrawer.vue
@@ -250,7 +250,7 @@ export default {
       return this.canSchedule && (!this.editMode || (this.publicationSettings?.publish || !!this.noteObject?.schedulePostDate));
     },
     saveEnabled() {
-      return (!this.editMode || this.publicationSettingsUpdated) && (this.canPublish && this.validPublishSettings);
+      return (!this.editMode || this.publicationSettingsUpdated) && this.validPublishSettings;
     },
     validPublishSettings() {
       return !this.publicationSettings?.publish || (this.publicationSettings?.publish && this.publicationSettings?.selectedTargets?.length);
@@ -310,6 +310,7 @@ export default {
     updateAdvancedSettings(settings) {
       this.advancedSettings = structuredClone(settings);
       this.publicationSettings.advancedSettings = this.advancedSettings;
+      this.currentPublicationSettings = { ...this.currentPublicationSettings };
       this.noteObject.properties.hideAuthor = this.advancedSettings?.hideAuthor;
       this.noteObject.properties.hideReaction = this.advancedSettings?.hideReaction;
     },


### PR DESCRIPTION
Prior to this change, a space member can not create articles in a non redactional space, this is due to the canPublish condition which returns always false for space member.
After this commit, we ensure to remove this useless condition to allow space members to create articles.