### PR TITLE
fix : error when creating the wiki in a space - MEED-8343

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -433,6 +433,7 @@ export default {
     },
     initialized() {
       if (this.initialized) {
+        Vue.prototype.$utils.includeExtensions('NotesExtension');
         const urlHash = window.location.hash;
         if (urlHash) {
           const elementId = urlHash.substring(1);
@@ -679,7 +680,6 @@ export default {
   },
   mounted() {
     this.handleChangePages();
-    Vue.prototype.$utils.includeExtensions('NotesExtension');
     $(document).on('click', () => {
       this.translationsMenu = false;
     });


### PR DESCRIPTION
Before this fix, when accessing to the note app of a space the first time, 2 request getNotePage are launched in parallel. As the wiki not exists, 2 requests to create it are launched It make the note app not accessible
This commit move the publish extension load after afte initialization

Resolves Meeds-io/meeds#2880

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
