### PR TITLE
fix: Fix TC WebSocket initialization in Vue prototype & Improve TC Portlet Cache - MEED-8361 - Meeds-io/meeds#2905

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -88,6 +88,8 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/termsAndConditionsView.html</value>
     </init-param>
+    <expiration-cache>-1</expiration-cache>
+    <cache-scope>PUBLIC</cache-scope>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -106,6 +108,8 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/termsAndConditionsUpdater.html</value>
     </init-param>
+    <expiration-cache>-1</expiration-cache>
+    <cache-scope>PUBLIC</cache-scope>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -123,6 +127,8 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/termsAndConditionsUserSettings.html</value>
     </init-param>
+    <expiration-cache>-1</expiration-cache>
+    <cache-scope>PUBLIC</cache-scope>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>

--- a/notes-webapp/src/main/webapp/vue-app/terms-and-condition-updater/services.js
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-condition-updater/services.js
@@ -19,7 +19,7 @@
  */
 import * as termsAndConditionsWebSocket from './js/WebSocket';
 
-if (!Vue.prototype.$connectorWebSocket) {
+if (!Vue.prototype.$termsAndConditionsWebSocket) {
   window.Object.defineProperty(Vue.prototype, '$termsAndConditionsWebSocket', {
     value: termsAndConditionsWebSocket,
   });


### PR DESCRIPTION
- Fix incorrect TC WebSocket property check in Vue prototype
- Since the Terms and conditions portlet serves static html files, the portlet cache can be used to retrieve statically the rendered DOM element.

Resolves Meeds-io/meeds#2905