### PR TITLE
fix: Initialize Websocket before subscribing to a channel - MEED-8371 - Meeds-io/meeds#2923

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/terms-and-condition-updater/js/WebSocket.js
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-condition-updater/js/WebSocket.js
@@ -16,6 +16,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 export function initCometd(callback) {
+  Vue.prototype.$socialWebSocket.initCometd('/TermsAndConditions');
   cCometd.subscribe('/TermsAndConditions', null, (event) => {
     const data = event.data && JSON.parse(event.data);
     if (!data) {


### PR DESCRIPTION
Prior to this change, when the T&C Updater is the only WebSocket Channel instantiated in a page, an error occurs when attempts to subscribe to a channel. This change ensures to initialize cometd before subscribing to a channel.

Resolves Meeds-io/meeds#2923