### PR TITLE
fix: Imported notes are not indexed during creation - MEED-8318 - Meeds-io/meeds#2805

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -2041,17 +2041,17 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
       note.setId(null);
       Page note_2 = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), note.getName());
       if (note_2 == null) {
-        note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, false);
+        note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, true);
         targetNote = note_;
       } else {
         if (StringUtils.isNotEmpty(conflict)) {
           if (conflict.equals("overwrite") || conflict.equals("replaceAll")) {
             deleteNote(wiki.getType(), wiki.getOwner(), note.getName());
-            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, false);
+            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, true);
             targetNote = note_;
           }
           if (conflict.equals("duplicate")) {
-            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, false);
+            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, true);
             targetNote = note_;
           }
           if (conflict.equals("update")) {


### PR DESCRIPTION
prior to this change, when import notes the creation event is not broadcasted which cause a non indexation issue of the imported notes. 
This PR ensures to broadcast the creation event of the imported note
