### PR TITLE
fix: Display note title in MENTION IN NOTE mail notification description - MEED-8357

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -260,6 +260,7 @@ SpaceSettings.application.notes.application.description=Notes Application
 UINotification.label.mentionInNote=Mentions in note
 UINotification.label.note=Notes Notifications
 note.notification.mention.in.note.description=You have been mentioned in a note:
+note.mailNotification.mention.in.note.description=You have been mentioned in a note: {0}
 Notification.label.types.notes=Notes
 UINotification.title.MentionInNoteNotificationPlugin=Someone mentions me in a note
 notes.notification.label.footer=If you do not want to receive such notifications, <a target="_blank" class="notification_settings_url" href="{0}">click here</a> to change your notification settings.

--- a/notes-webapp/src/main/webapp/WEB-INF/notification/templates/mail/MentionInNoteNotificationPlugin.gtmpl
+++ b/notes-webapp/src/main/webapp/WEB-INF/notification/templates/mail/MentionInNoteNotificationPlugin.gtmpl
@@ -58,7 +58,7 @@ $title
 <td align="left" bgcolor="#ffffff" width="90%" align="top" style="width: 90%; background-color: #ffffff; padding: 0 0; vertical-align: top;">
 <p style="margin: 0 0 10px; color: #333333; font-size: 13px; line-height: 18px;">
 <%
-def notificationDescription = _ctx.appRes("note.notification.mention.in.note.description");
+def notificationDescription = _ctx.appRes("note.mailNotification.mention.in.note.description",NOTE_TITLE);
 %>
 </p>
 	<table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#f9f9f9" align="center" style="margin:0 0 10px; width: 100%; background-color: #f9f9f9; font-size: 13px; color:#333333;line-height: 18px;">


### PR DESCRIPTION


Prior to this change, the note title is not display in MENTION IN NOTE mail notification description which makes its not clear for notified users. After this commit, we ensure to display the note title for this mail notification.