### PR TITLE
fix: Note translation of current user lang is not correctly displayed when open note from toc - MEED-8334 - Meeds-io/meeds#2862

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -610,6 +610,9 @@ export default {
     },
     canScheduleNotePublication() {
       return this.note?.canManage || this.canSchedule;
+    },
+    targetLang() {
+      return this.selectedTranslation?.value || this.lang;
     }
   },
   created() {
@@ -746,6 +749,9 @@ export default {
       this.noteSummary = summary;
     },
     updateSelectedTranslation(translation) {
+      if (!this.initialized) {
+        return;
+      }
       this.selectedTranslation = translation;
     },
     getNoteLink(noteId) {
@@ -899,15 +905,14 @@ export default {
       });
     },
     getNoteByName(noteName, source, viewNote) {
-      return this.$notesService.getNote(this.noteBookType, this.noteBookOwner, noteName, source, this.selectedTranslation.value).then(data => {
+      return this.$notesService.getNote(this.noteBookType, this.noteBookOwner, noteName, source, this.targetLang).then(data => {
         this.note = data || {};
         this.isDraft = data.draftPage;
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
         this.getNoteLanguages(this.note.id);
-        if (!this.note.lang || this.note.lang === '') {
-          this.updateSelectedTranslation(this.originalVersion);
-        }
+        const translation = this.note.lang ? { value: this.targetLang } : this.originalVersion;
+        this.updateSelectedTranslation(translation);
         this.updateURL();
         if (viewNote){
           this.viewNoteStatistics(this.note);


### PR DESCRIPTION
Prior to this change, Note of current user lang translation is not correctly displayed when open note from toc because of wrong value of fetched translation lang which is not get updated when open the note from toc.
This PR ensures to fetch the correct target translation lang.
Resolves https://github.com/Meeds-io/meeds/issues/2862
