### PR TITLE
fix: media embedded Video not displayed in SNV - MEED-8360 - Meeds-io/meeds#2893

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageView.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageView.vue
@@ -38,6 +38,7 @@ export default {
       const DOMPurify = require('dompurify');
       const pageContent = this.$root.pageContent && this.$noteUtils.getContentToDisplay(this.$root.pageContent) || '';
       const sanitizedContent = DOMPurify.sanitize(pageContent, {
+        ADD_TAGS: ['iframe'],
         tagNameCheck: () => true,
         attributeNameCheck: () => true,
       });


### PR DESCRIPTION
Before this change, when create an SNV with a media embed and save the SNV, the media is not displayed. To resolve this problem, add the ADD_TAGS: [iframe] property to the DOMPurify configuration. After this change, SNV is displayed correctly.

(cherry picked from commit 07b079de47601b820a90302782faf320851d756d)