### PR TITLE
fix: Notes rich editor extensions not opened when editing an article - MEED-8390 - Meeds-io/meeds#2935

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -74,7 +74,7 @@
       </div>
     </div>
     <extension-registry-components
-      v-if="initialized && editorExtensions.length > 0"
+      v-if="editorExtensions.length > 0"
       name="NotesRichEditor"
       type="notes-editor-extensions"
       :params="extensionParams" />
@@ -109,7 +109,7 @@ export default {
     return {
       noteObject: null,
       editor: null,
-      initialized: false,
+      noteContentInitialized: false,
       instanceReady: false,
       noteTitleMaxLength: 500,
       typingTimer: null,
@@ -229,7 +229,7 @@ export default {
       this.updateData();
     },
     'noteObject.content': function () {
-      if (this.initialized) {
+      if (this.noteContentInitialized) {
         this.updateData();
       }
     },
@@ -501,7 +501,7 @@ export default {
             self.setToolBarEffect();
           },
           change: function (evt) {
-            if (!self.initialized || self.isContentImagesUploadProgress) {
+            if (!self.noteContentInitialized || self.isContentImagesUploadProgress) {
               // First time setting data
               self.initialized = true;
               return;


### PR DESCRIPTION
Prior to this change, the rich text editor extensions for notes were not opening when editing an article. This issue was caused by a regression that added the `initialized` variable to the condition for adding the extension to the component template. However, the `initialized` variable is meant to check whether the object content has been initialized, not to determine if the data component is initialized.
This change corrects the regression and renames the variable to make it more descriptive, avoiding confusion.