### PR TITLE
fix: DRAFT article/note content not saved if content added after title - MEED-8447_MEED-8448 - Meeds-io/meeds#2968_Meeds-io/meeds#2970

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -499,7 +499,7 @@ export default {
           change: function (evt) {
             if (!self.noteContentInitialized || self.isContentImagesUploadProgress) {
               // First time setting data
-              self.initialized = true;
+              self.noteContentInitialized = true;
               return;
             }
             self.waitUserTyping(self);


### PR DESCRIPTION
Prior to this change, article/note content was neither saved nor updated if the content was added after the title. This issue was caused by the incorrect assignment of the variable noteContentInitialized, which was always false. This change correctly binds the variable, resolving the issue

