### PR TITLE
fix: Note attachments lost after publishing - MEED-8446 - Meeds-io/meeds#2966

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1046,6 +1046,8 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
    */
   @Override
   public void createVersionOfNote(Page note, String userName) throws WikiException {
+    DraftPage draftPage = dataStorage.getLatestDraftPageByTargetPageAndLang(Long.valueOf(note.getId()), note.getLang());
+    PageVersion previousPageVersion = getPublishedVersionByPageIdAndLang(Long.parseLong(note.getId()), note.getLang());
     PageVersion pageVersion = dataStorage.addPageVersion(note, userName);
     pageVersion.setAttachmentObjectType(note.getAttachmentObjectType());
     updateVersionContentImages(pageVersion);
@@ -1074,13 +1076,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
                              NOTE_METADATA_VERSION_PAGE_OBJECT_TYPE,
                              userName);
     }
-    DraftPage draftPage = dataStorage.getLatestDraftPageByTargetPageAndLang(Long.valueOf(note.getId()), note.getLang());
-    if (draftPage != null) {
-      Map<String, String> eventData = new HashMap<>();
-      eventData.put("draftPageId", draftPage.getId());
-      eventData.put("pageVersionId", pageVersionId);
-      Utils.broadcast(listenerService, "note.page.version.created", this, eventData);
-    }
+    broadcastPageVersionCreationEvent(pageVersionId, draftPage != null ? draftPage.getId() : null, previousPageVersion != null ? previousPageVersion.getId() : null);
   }
 
   /**
@@ -2548,6 +2544,19 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
       }
     }
     return processedContent;
+  }
+
+  private void broadcastPageVersionCreationEvent(String pageVersionId, String draftPageId, String previousPageVersionId) {
+    Map<String, String> eventData = new HashMap<>();
+    if (draftPageId != null) {
+      eventData.put("draftPageId", draftPageId);
+    } else if (previousPageVersionId != null) {
+      eventData.put("previousPageVersionId", previousPageVersionId);
+    }
+    if (!eventData.isEmpty()) {
+      eventData.put("pageVersionId", pageVersionId);
+      Utils.broadcast(listenerService, "note.page.version.created", this, eventData);
+    }
   }
 
  }


### PR DESCRIPTION
Prior to this change, note attachments were lost after publishing. This issue was caused by a missing link between the attachment and the newly created version during publishing. This update ensures that attachments are properly linked during publishing, resolving the issue.
