### PR TITLE
fix: Prevent processing note mention notifications when creating or updating an article - MEED-8468 - Meeds-io#2852

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -342,10 +342,10 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
     Utils.broadcast(listenerService, "note.posted", note.getAuthor(), createdPage);
     if (broadcast) {
       postAddPage(noteBook.getType(), noteBook.getOwner(), note.getName(), createdPage);
-    }
-    Matcher mentionMatcher = Utils.MENTION_PATTERN.matcher(createdPage.getContent());
-    if (mentionMatcher.find()) {
-      Utils.sendMentionInNoteNotification(createdPage, null, createdPage.getAuthor());
+      Matcher mentionMatcher = Utils.MENTION_PATTERN.matcher(createdPage.getContent());
+      if (mentionMatcher.find()) {
+        Utils.sendMentionInNoteNotification(createdPage, null, createdPage.getAuthor());
+      }
     }
     return createdPage;
   }
@@ -412,16 +412,15 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
       updatedPage.setMetadatas(metadata);
       note.setAuthor(userIdentity.getUserId());
     }
-
-    Matcher mentionsMatcher = Utils.MENTION_PATTERN.matcher(note.getContent());
-    if (mentionsMatcher.find()) {
-      Utils.sendMentionInNoteNotification(note,
-                                          existingNote,
-                                          userIdentity != null ? userIdentity.getUserId() : existingNote.getAuthor());
-    }
     Utils.broadcast(listenerService, "note.updated", note.getAuthor(), updatedPage);
     if (broadcast) {
       postUpdatePage(updatedPage.getWikiType(), updatedPage.getWikiOwner(), updatedPage.getName(), updatedPage, type);
+      Matcher mentionsMatcher = Utils.MENTION_PATTERN.matcher(note.getContent());
+      if (mentionsMatcher.find()) {
+        Utils.sendMentionInNoteNotification(note,
+                                            existingNote,
+                                            userIdentity != null ? userIdentity.getUserId() : existingNote.getAuthor());
+      }
     }
     updatedPage.setLang(note.getLang());
     return updatedPage;


### PR DESCRIPTION
Prior to this change, creating or updating a content article processed note notification mentions in the same way as preventing duplicate indexing of articles as notes using the broadcast attribute. This change will prevent note mention processing when creating or updating an article.