### PR TITLE
FIX: User identified after a publication - Meeds-io/meeds#8377

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -258,7 +258,6 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
         if (properties != null) {
           properties.setNoteId(Long.parseLong(createdPage.getId()));
           properties.setDraft(false);
-          properties.setSummary("");
           properties = saveNoteMetadata(properties,
                                         note.getLang(),
                                         Long.valueOf(identityManager.getOrCreateUserIdentity(userIdentity.getUserId()).getId()));
@@ -1785,7 +1784,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
     if (metadataItem != null && metadataItem.getProperties() != null) {
       properties = metadataItem.getProperties();
     }
-    properties.put(SUMMARY_PROP, notePageProperties.getSummary());
+    properties.put(SUMMARY_PROP, notePageProperties.getSummary() != null ? notePageProperties.getSummary() : "");
     properties.put(HIDE_AUTHOR_PROP, String.valueOf(notePageProperties.isHideAuthor()));
     properties.put(HIDE_REACTION_PROP, String.valueOf(notePageProperties.isHideReaction()));
     if (featuredImageId != null) {


### PR DESCRIPTION
Prior to this fix, When a note is published new version is created twice, this due that summary on note creation is null but in the metadata on publish is "". This commit set the summary to "" so it will not be considered as changed on publication and no version will be created.