### PR TITLE
fix: When import notes, if there request upload have a little delay (more than 200ms), the upload fails - MEED-8494

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/importNotes/AttachmentsNotesUploadInput.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/importNotes/AttachmentsNotesUploadInput.vue
@@ -171,8 +171,12 @@ export default {
         this.processNextQueuedUpload();
       } else {
         window.setTimeout(() => {
+          if (!file.countFirstProgressError) {
+            file.countFirstProgressError=0;
+          }
           this.$uploadService.getUploadProgress(file.uploadId)
             .then(percent => {
+              delete file.countFirstProgressError;
               if (!percent) {
                 return;
               } else {
@@ -185,12 +189,19 @@ export default {
                 }
               }
             })
-            .catch(() => {
-              this.removeAttachedFile(file);
-              this.$root.$emit('attachments-notification-alert', {
-                message: this.$t('attachments.link.failed'),
-                type: 'error',
-              });
+            .catch((err) => {
+              if (err.message==='Uploaded resource not found' && file.countFirstProgressError != null && file.countFirstProgressError < 5) {
+                //if the upload request take more than 200ms to initialize, then the progress request arrives too early.
+                //In this case, redo the progress, until 5 errors to be sure
+                file.countFirstProgressError++;
+                this.controlUpload(file);
+              } else {
+                this.removeAttachedFile(file);
+                this.$root.$emit('attachments-notification-alert', {
+                  message: this.$t('attachments.link.failed'),
+                  type: 'error',
+                });
+              }
             });
         }, 200);
       }
@@ -199,6 +210,9 @@ export default {
       if (this.uploadingFilesQueue.length > 0) {
         this.sendFileToServer(this.uploadingFilesQueue.shift());
       }
+    },
+    removeAttachedFile: function() {
+      this.$root.$emit('delete-uploaded-file', this.attachment);
     },
   }
 };


### PR DESCRIPTION
Before this fix, if the progress request is treaten by the server before the upload request (due to latency problem for example), the upload fails on browser side This commit add a replay of the progress request (5 times max) in order to accept some latency on upload request

Resolves meeds-io/meeds#3025

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
