### PR TITLE
fix: SNV update issue - MEED-8517 Meeds-io/meeds#3064

### DIFF
--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/ckeditor/plugins/insertImage/plugin.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/ckeditor/plugins/insertImage/plugin.js
@@ -87,7 +87,7 @@
       }
 
       editor.on('contentDom', function () {
-        const iframeWin = window.document.getElementsByTagName('iframe')[0].contentWindow;
+        const iframeWin = window.document.querySelector('iframe.cke_wysiwyg_frame.cke_reset').contentWindow;
         iframeWin.addEventListener('drop',function(event){
           if (event.dataTransfer.getData('cke/widget-id')){
             const sourceWidget = editor.widgets.instances[event.dataTransfer.getData('cke/widget-id')];


### PR DESCRIPTION
Before this change, when an embedded link exist in activity or SNV, It is impossible to update other bloc of contents. To fix this problem, change the get type of the iframe element. After this change, It is possible to update any block of content.

(cherry picked from commit 05cf39ff995337402a275999997c6225a5126382)