### PR TITLE
fix: Fix publishing drawer displaying instead of edit publishing drawer after note publication - MEED-8507 - Meeds-io/meeds#3031

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -324,7 +324,7 @@
         canPublish: canPublish,
         canSchedule: canScheduleNotePublication
       }"
-      :edit-mode="false"
+      :edit-mode="published"
       @publish="publishNote" />
   </v-app>
 </template>


### PR DESCRIPTION
Prior to this change, the publishing drawer was displayed instead of the edit publishing drawer after note publication. This issue was due to the editMode prop always being false. This change binds the editMode prop correctly, resolving the issue.