### PR TITLE
fix: Fix note treeview search - MEED-8530 - Meeds-io/meeds#3062

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/JPADataStorage.java
@@ -146,6 +146,7 @@ public class JPADataStorage implements DataStorage {
 
     List<SearchResult> searchResults = searchService.searchWiki(getSearchedText(wikiSearchData),
                                                                 wikiSearchData.getUserId(),
+                                                                wikiSearchData.getWikiOwner(),
                                                                 wikiSearchData.getTagNames(),
                                                                 wikiSearchData.isFavorites(),
                                                                 wikiSearchData.isNotesTreeFilter(),

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -135,12 +135,12 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
     return StringUtils.join(sourceFields, ",");
   }
 
-  public List<SearchResult> searchWiki(String searchedText, String userId, List<String> tagNames, boolean isFavorites, boolean isNotesTreeFilter, int offset, int limit) {
-      return filteredWikiSearch(searchedText, userId, tagNames, isFavorites, isNotesTreeFilter, offset, limit);
+  public List<SearchResult> searchWiki(String searchedText, String userId, String wikiOwner, List<String> tagNames, boolean isFavorites, boolean isNotesTreeFilter, int offset, int limit) {
+      return filteredWikiSearch(searchedText, userId, wikiOwner, tagNames, isFavorites, isNotesTreeFilter, offset, limit);
   }
 
-  protected List<SearchResult> filteredWikiSearch(String query, String userId, List<String> tagNames, boolean isFavorites,boolean isNotesTreeFilter , int offset, int limit) {
-    Set<String> ids = getUserSpaceIds(userId);
+  protected List<SearchResult> filteredWikiSearch(String query, String userId, String wikiOwner, List<String> tagNames, boolean isFavorites,boolean isNotesTreeFilter , int offset, int limit) {
+    Set<String> ids = getUserSpaceIds(userId, wikiOwner);
     String esQuery = buildQueryStatement(ids, userId, tagNames, query, isFavorites, isNotesTreeFilter,offset, limit);
     String jsonResponse = getClient().sendRequest(esQuery, getIndex());
     return buildWikiResult(jsonResponse);
@@ -335,7 +335,7 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
 
   }
 
-  protected Set<String> getUserSpaceIds(String userId) {
+  protected Set<String> getUserSpaceIds(String userId, String wikiOwner) {
     if (StringUtils.isEmpty(userId)) {
       throw new IllegalStateException("No Identity found: userId is empty");
     }  else {
@@ -351,7 +351,12 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
       }
       for (Space space : spaceList) {
         if (space != null) {
-          permissions.add(identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName()).getId());
+          if (wikiOwner == null || space.getGroupId().equals(wikiOwner)) {
+            permissions.add(identityManager.getOrCreateIdentity(SpaceIdentityProvider.NAME, space.getPrettyName()).getId());
+            if (wikiOwner != null) {
+              break;  
+            }
+          }
         }
       }
       Identity userIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME,

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1282,6 +1282,8 @@ public class NotesRestService implements ResourceContainer {
       data.setNotesTreeFilter(isNotesTreeFilter);
       data.setFavorites(favorites);
       data.setTagNames(tagNames);
+      data.setWikiOwner(wikiOwner);
+      data.setWikiType(wikiType);
       List<SearchResult> results = noteService.search(data).getAll();
       List<TitleSearchResult> titleSearchResults = new ArrayList<>();
       for (SearchResult searchResult : results) {

--- a/notes-service/src/test/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnectorTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnectorTest.java
@@ -144,7 +144,7 @@ public class WikiElasticSearchServiceConnectorTest extends AbstractKernelTest {
     // when
     List<String> tagNames = new ArrayList<>();
     tagNames.add("testNoteTag");
-    List<SearchResult> searchResults = searchServiceConnector.searchWiki("*","__system", tagNames, false, false, 0, 20);
+    List<SearchResult> searchResults = searchServiceConnector.searchWiki("*","__system", null, tagNames, false, false, 0, 20);
 
     // Then
     assertNotNull(searchResults);

--- a/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
+++ b/notes-webapp/src/main/webapp/javascript/eXo/wiki/notesService.js
@@ -430,9 +430,9 @@ export function removeNoteFeaturedImage(noteId, isDraft, lang) {
   });
 }
 
-export function searchNotes(keyword, limit) {
+export function searchNotes(keyword, wikiOwner, limit) {
   document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-  return fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/contextsearch?keyword=${keyword}&isNotesTreeFilter=true&limit=${limit}`, {
+  return fetch(`${notesConstants.PORTAL}/${notesConstants.PORTAL_REST}/notes/contextsearch?keyword=${keyword}&wikiOwner=${wikiOwner}&isNotesTreeFilter=true&limit=${limit}`, {
     method: 'GET',
     credentials: 'include',
   }).then(resp => {

--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
@@ -988,7 +988,7 @@ export default {
         if (this.isDraftFilter) {
           this.items = this.filterItemsDraft.filter(item => item.name.includes(this.search));
         } else { 
-          this.$notesService.searchNotes(this.search, this.limit).then(data => {
+          this.$notesService.searchNotes(this.search, `/${this.note.wikiOwner}`, this.limit).then(data => {
             this.items = data?.jsonList.length ? this.toListNotes(data?.jsonList) : [];         
             this.showTree = !!this.items.length;
           });


### PR DESCRIPTION
Prior to this change, when we search by name from space note treeview, we can get results from different all user spaces not only the current space. After this commit, we will ensure that the search retrieves only results which belong to the current space.

Resolves https://github.com/Meeds-io/meeds/issues/3062