### PR TITLE
fix: Allow space publishers to move note and edit note/article posting and publishing in redactional spaces - MEED-8450 - Meeds-io/meeds#2969

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -374,7 +374,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
       throw new EntityNotFoundException("Note to update not found");
     }
     Space space = spaceService.getSpaceByGroupId(note.getWikiOwner());
-    if (userIdentity != null && !Utils.canManageNotes(userIdentity.getUserId(), space, existingNote)) {
+    if (userIdentity != null && (!Utils.canManageNotes(userIdentity.getUserId(), space, existingNote) && !spaceService.canPublishOnSpace(space, userIdentity.getUserId()))) {
       throw new IllegalAccessException("User does not have edit the note.");
     }
     if (PageUpdateType.EDIT_PAGE_CONTENT.equals(type) || PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE.equals(type)
@@ -556,7 +556,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
       }
       if (moveNote != null) {
         Space space = spaceService.getSpaceByGroupId(moveNote.getWikiOwner());
-        if (!Utils.canManageNotes(userIdentity.getUserId(), space, moveNote)) {
+        if (!Utils.canManageNotes(userIdentity.getUserId(), space, moveNote) && !spaceService.canPublishOnSpace(space, userIdentity.getUserId())) {
           throw new IllegalAccessException("User does not have edit the note.");
         }
       }


### PR DESCRIPTION
Prior to this change, space publisher can not move or edit note/article posting and publishing in redactional spaces due to missing permission in updateNote method. After this commit, we ensure to add this needed permission.

Resolves https://github.com/Meeds-io/meeds/issues/2969