### PR TITLE
fix: Fix notes search when a note is deleted - MEED-8581 -  Meeds-io/meeds#3081

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1287,11 +1287,17 @@ public class NotesRestService implements ResourceContainer {
       List<SearchResult> results = noteService.search(data).getAll();
       List<TitleSearchResult> titleSearchResults = new ArrayList<>();
       for (SearchResult searchResult : results) {
-        Page page = noteService.getNoteOfNoteBookByName(searchResult.getWikiType(),
-                                                        searchResult.getWikiOwner(),
-                                                        searchResult.getPageName(),
-                                                        searchResult.getLang(),
-                                                        currentIdentity);
+        Page page = null;
+        try {
+          page = noteService.getNoteOfNoteBookByName(searchResult.getWikiType(),
+                                                     searchResult.getWikiOwner(),
+                                                     searchResult.getPageName(),
+                                                     searchResult.getLang(),
+                                                     currentIdentity);
+        } catch (Exception e) {
+          log.error("Cannot get page of search result " + searchResult.getWikiType() + ":" + searchResult.getWikiOwner() + ":"
+              + searchResult.getPageName(), e);
+        }
         if (page != null) {
           page.setUrl(searchResult.getUrl() != null && !searchResult.getUrl().isBlank() ? searchResult.getUrl() : page.getUrl() + "?translation="+ searchResult.getLang());
           if (SearchResultType.ATTACHMENT.equals(searchResult.getType())) {
@@ -1339,14 +1345,12 @@ public class NotesRestService implements ResourceContainer {
             titleSearchResult.setMetadatas(page.getMetadatas());
             titleSearchResults.add(titleSearchResult);
           }
-        } else {
-          log.warn("Cannot get page of search result " + searchResult.getWikiType() + ":" + searchResult.getWikiOwner() + ":"
-                  + searchResult.getPageName());
         }
       }
       return Response.ok(new BeanToJsons(titleSearchResults), MediaType.APPLICATION_JSON).cacheControl(cc).build();
     } catch (Exception e) {
-      return Response.status(HTTPStatus.INTERNAL_ERROR).cacheControl(cc).build();
+      log.error("Error when search notes", e);
+      return Response.serverError().build();
     }
   }
 


### PR DESCRIPTION
Prior to this change, when a note is deleted but not unindexed on ES for some reasons, the notes search is failed and not return any note even if some notes are matching the search term. This is due to the noteService.getNoteOfNoteBookByName method into the searchResult loop of searchData rest service which raises a global server error.
After this commit, we ensure to catch the error of this method allowing to continue the search results loop execution.

Resolves https://github.com/Meeds-io/meeds/issues/3081