### PR TITLE
FIX: User identified after a publication - Meeds-io/meeds#8377

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -258,7 +258,6 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
         if (properties != null) {
           properties.setNoteId(Long.parseLong(createdPage.getId()));
           properties.setDraft(false);
-          properties.setSummary("");
           properties = saveNoteMetadata(properties,
                                         note.getLang(),
                                         Long.valueOf(identityManager.getOrCreateUserIdentity(userIdentity.getUserId()).getId()));
@@ -1801,7 +1800,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
     if (metadataItem != null && metadataItem.getProperties() != null) {
       properties = metadataItem.getProperties();
     }
-    properties.put(SUMMARY_PROP, notePageProperties.getSummary());
+    properties.put(SUMMARY_PROP, notePageProperties.getSummary() != null ? notePageProperties.getSummary() : "");
     properties.put(HIDE_AUTHOR_PROP, String.valueOf(notePageProperties.isHideAuthor()));
     properties.put(HIDE_REACTION_PROP, String.valueOf(notePageProperties.isHideReaction()));
     if (featuredImageId != null) {

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -258,6 +258,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
         if (properties != null) {
           properties.setNoteId(Long.parseLong(createdPage.getId()));
           properties.setDraft(false);
+          properties.setSummary("");
           properties = saveNoteMetadata(properties,
                                         note.getLang(),
                                         Long.valueOf(identityManager.getOrCreateUserIdentity(userIdentity.getUserId()).getId()));


### PR DESCRIPTION
Prior to this fix, when a note is published, a new version is created twice. This is because the summary on note creation is null, but in the metadata on publish, it is "". 
This commit sets the summary to "" if it's null, so it will not be considered changed upon publication and no version will be created.