### PR TITLE
fix: Accented notes aren't displayed when making a search in notes tree - MEED-8699 - Meeds-io/meeds#3178

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -87,7 +87,7 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
   public static final String         WILDCARD_QUERY            = """
           {
             "wildcard": {
-              "name": "*@term@*"
+              "title": "*@term@*"
             }
           }
           """;


### PR DESCRIPTION
Prior to this change, accented notes were not displayed when searching in the notes tree. This issue occurred because the search was based on the name field, which was stripped of special characters. This change modifies the search to use the title instead.
Resolves https://github.com/meeds-io/meeds/issues/3178


