### PR TITLE
fix: Prevent having a loop redirection in termsAndCondtions web handler - MEED-77031 - Meeds-io/meeds#3215

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/handler/TermsAndConditionsHandler.java
+++ b/notes-service/src/main/java/io/meeds/notes/handler/TermsAndConditionsHandler.java
@@ -21,30 +21,46 @@ package io.meeds.notes.handler;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.meeds.notes.service.TermsAndConditionsService;
-import jakarta.servlet.*;
+import jakarta.annotation.PostConstruct;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.WebRequestHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Component
 public class TermsAndConditionsHandler extends WebRequestHandler {
 
-  public static final String        PAGE_URI = "terms-and-conditions";
+  public static final String              PAGE_URI     = "terms-and-conditions";
 
-  private UserPortalConfigService   userPortalConfigService;
+  private final UserPortalConfigService   userPortalConfigService;
 
-  private TermsAndConditionsService termsAndConditionsService;
+  private final TermsAndConditionsService termsAndConditionsService;
 
-  @Override
-  public void onInit(WebAppController controller, ServletConfig sConfig) throws Exception {
-    super.onInit(controller, sConfig);
+  private final WebAppController          webAppController;
 
-    PortalContainer container = PortalContainer.getInstance();
-    this.userPortalConfigService = container.getComponentInstanceOfType(UserPortalConfigService.class);
-    this.termsAndConditionsService = container.getComponentInstanceOfType(TermsAndConditionsService.class);
+  @Value("#{'${io.meeds.termsAndConditions.excludedUris:}'.split(',')}")
+  private List<String>                    excludedUris = new ArrayList<>();
+
+  @Autowired
+  public TermsAndConditionsHandler(UserPortalConfigService userPortalConfigService,
+                                   TermsAndConditionsService termsAndConditionsService,
+                                   WebAppController webAppController) {
+    this.userPortalConfigService = userPortalConfigService;
+    this.termsAndConditionsService = termsAndConditionsService;
+    this.webAppController = webAppController;
+  }
+
+  @PostConstruct
+  public void init() {
+    webAppController.register(this);
   }
 
   @Override
@@ -61,47 +77,62 @@ public class TermsAndConditionsHandler extends WebRequestHandler {
   public boolean execute(ControllerContext controllerContext) throws Exception {
     String username = controllerContext.getRequest().getRemoteUser();
     String requestURI = controllerContext.getRequest().getRequestURI();
-    if (username == null || termsAndConditionsService == null || userPortalConfigService == null) {
+
+    if (username == null || isExcludedUri(requestURI)) {
       return false;
     }
+
     String language = controllerContext.getRequest().getLocale().getLanguage();
     boolean hasAcceptedTerms = termsAndConditionsService.isTermsAcceptedForUser(username, language);
 
-    if (hasAcceptedTerms && requestURI.contains(PAGE_URI) && controllerContext.getRequest().getQueryString() == null) {
-      controllerContext.getResponse()
-                       .sendRedirect(String.format("%s/%s/settings#terms-and-conditions",
-                                                   controllerContext.getRequest().getContextPath(),
-                                                   userPortalConfigService.getMetaPortal()));
+    if (hasAcceptedTerms && isTermsPage(requestURI) && controllerContext.getRequest().getQueryString() == null) {
+      redirectToUserSettings(controllerContext);
       return true;
     }
+
     if (!hasAcceptedTerms && !isTermsPage(requestURI)) {
-      String queryString = controllerContext.getRequest().getQueryString();
-
-      if (queryString != null) {
-        requestURI += "?" + queryString;
-      }
-      String initURI = "/" + PortalContainer.getCurrentPortalContainerName() + "/";
-
-      if (initURI.equals(requestURI)) {
-        controllerContext.getResponse()
-                         .sendRedirect(String.format("%s/%s/settings#terms-and-conditions?redirect=%s",
-                                                     controllerContext.getRequest().getContextPath(),
-                                                     userPortalConfigService.getMetaPortal(),
-                                                     userPortalConfigService.getDefaultPath(username)));
-      } else {
-        String encodedPreviousPage = URLEncoder.encode(requestURI, StandardCharsets.UTF_8);
-        controllerContext.getResponse()
-                         .sendRedirect(String.format("%s/%s/terms-and-conditions?redirect=%s",
-                                                     controllerContext.getRequest().getContextPath(),
-                                                     userPortalConfigService.getMetaPortal(),
-                                                     encodedPreviousPage));
-      }
+      redirectToTermsPage(controllerContext, requestURI, username);
       return true;
     }
+
     return false;
   }
 
-  private boolean isTermsPage(String requestURI) {
-    return requestURI.contains(PAGE_URI);
+  private void redirectToUserSettings(ControllerContext ctx) throws Exception {
+    String target = String.format("%s/%s/settings#terms-and-conditions",
+                                  ctx.getRequest().getContextPath(),
+                                  userPortalConfigService.getMetaPortal());
+    ctx.getResponse().sendRedirect(target);
+  }
+
+  private void redirectToTermsPage(ControllerContext ctx, String requestURI, String username) throws Exception {
+    String queryString = ctx.getRequest().getQueryString();
+    if (queryString != null) {
+      requestURI += "?" + queryString;
+    }
+
+    String basePortalPath = "/" + PortalContainer.getCurrentPortalContainerName() + "/";
+    String contextPath = ctx.getRequest().getContextPath();
+    String metaPortal = userPortalConfigService.getMetaPortal();
+
+    String redirectUrl = requestURI.equals(basePortalPath)
+                                                           ? String.format("%s/%s/settings#terms-and-conditions?redirect=%s",
+                                                                           contextPath,
+                                                                           metaPortal,
+                                                                           userPortalConfigService.getDefaultPath(username))
+                                                           : String.format("%s/%s/terms-and-conditions?redirect=%s",
+                                                                           contextPath,
+                                                                           metaPortal,
+                                                                           URLEncoder.encode(requestURI, StandardCharsets.UTF_8));
+
+    ctx.getResponse().sendRedirect(redirectUrl);
+  }
+
+  private boolean isTermsPage(String uri) {
+    return uri.contains(PAGE_URI);
+  }
+
+  private boolean isExcludedUri(String uri) {
+    return excludedUris.stream().anyMatch(uri::contains);
   }
 }

--- a/notes-service/src/main/resources/conf/portal/configuration.xml
+++ b/notes-service/src/main/resources/conf/portal/configuration.xml
@@ -280,13 +280,4 @@
     </component-plugin>
   </external-component-plugins>
 
-  <external-component-plugins>
-    <target-component>org.exoplatform.web.WebAppController</target-component>
-    <component-plugin>
-      <name>TermsAndConditionsHandler</name>
-      <set-method>register</set-method>
-      <type>io.meeds.notes.handler.TermsAndConditionsHandler</type>
-    </component-plugin>
-  </external-component-plugins>
-
 </configuration>

--- a/notes-service/src/test/java/io/meeds/notes/handler/TermsAndConditionsHandlerTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/handler/TermsAndConditionsHandlerTest.java
@@ -19,116 +19,112 @@
 package io.meeds.notes.handler;
 
 import io.meeds.notes.service.TermsAndConditionsService;
-import jakarta.servlet.ServletConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.WebAppController;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Field;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest(classes = { TermsAndConditionsHandler.class, })
+@ExtendWith(MockitoExtension.class)
 class TermsAndConditionsHandlerTest {
 
   @Mock
-  private WebAppController          webAppController;
-
-  @Mock
-  private ServletConfig             servletConfig;
-
-  @MockBean
-  ControllerContext                 controllerContext;
-
-  @MockBean
-  private HttpServletRequest        httpRequest;
-
-  @MockBean
-  private HttpServletResponse       httpResponse;
-
-  @MockBean
   private TermsAndConditionsService termsService;
 
-  @MockBean
-  private UserPortalConfigService   portalConfigService;
+  @Mock
+  private UserPortalConfigService portalConfigService;
 
-  @MockBean
-  private PortalContainer           container;
+  @Mock
+  private WebAppController webAppController;
 
-  @Autowired
+  @Mock
+  private ControllerContext controllerContext;
+
+  @Mock
+  private HttpServletRequest httpRequest;
+
+  @Mock
+  private HttpServletResponse httpResponse;
+
+  @InjectMocks
   private TermsAndConditionsHandler handler;
 
   @Test
   void testUserHasAcceptedTermsAndRequestIsForTermsPage() throws Exception {
-    when(container.getComponentInstanceOfType(TermsAndConditionsService.class)).thenReturn(termsService);
-    when(container.getComponentInstanceOfType(UserPortalConfigService.class)).thenReturn(portalConfigService);
     when(controllerContext.getRequest()).thenReturn(httpRequest);
     when(controllerContext.getResponse()).thenReturn(httpResponse);
-    when(httpRequest.getContextPath()).thenReturn("/portal");
     when(httpRequest.getRemoteUser()).thenReturn("testUser");
     when(httpRequest.getRequestURI()).thenReturn("/portal/terms-and-conditions");
     when(httpRequest.getQueryString()).thenReturn(null);
     when(httpRequest.getLocale()).thenReturn(Locale.ENGLISH);
     when(termsService.isTermsAcceptedForUser("testUser", "en")).thenReturn(true);
     when(portalConfigService.getMetaPortal()).thenReturn("classic");
+    when(httpRequest.getContextPath()).thenReturn("/portal");
 
-    try (MockedStatic<PortalContainer> mockedStatic = mockStatic(PortalContainer.class)) {
-      mockedStatic.when(PortalContainer::getInstance).thenReturn(container);
-      handler.onInit(webAppController, servletConfig);
-      boolean executed = handler.execute(controllerContext);
+    boolean executed = handler.execute(controllerContext);
 
-      verify(httpResponse).sendRedirect("/portal/classic/settings#terms-and-conditions");
-      assertTrue(executed);
-    }
+    verify(httpResponse).sendRedirect("/portal/classic/settings#terms-and-conditions");
+    assertTrue(executed);
   }
 
   @Test
   void testUserHasNotAcceptedTerms() throws Exception {
-    when(container.getComponentInstanceOfType(TermsAndConditionsService.class)).thenReturn(termsService);
-    when(container.getComponentInstanceOfType(UserPortalConfigService.class)).thenReturn(portalConfigService);
     when(controllerContext.getRequest()).thenReturn(httpRequest);
     when(controllerContext.getResponse()).thenReturn(httpResponse);
-    when(httpRequest.getContextPath()).thenReturn("/portal");
     when(httpRequest.getRemoteUser()).thenReturn("testUser");
     when(httpRequest.getRequestURI()).thenReturn("/portal/home");
     when(httpRequest.getLocale()).thenReturn(Locale.ENGLISH);
-    when(termsService.isTermsAcceptedForUser("testUser", null)).thenReturn(false);
+    when(httpRequest.getContextPath()).thenReturn("/portal");
+    when(httpRequest.getQueryString()).thenReturn(null);
+    when(termsService.isTermsAcceptedForUser("testUser", "en")).thenReturn(false);
     when(portalConfigService.getMetaPortal()).thenReturn("classic");
 
-    try (MockedStatic<PortalContainer> mockedStatic = mockStatic(PortalContainer.class)) {
-      mockedStatic.when(PortalContainer::getInstance).thenReturn(container);
-      handler.onInit(webAppController, servletConfig);
-      boolean executed = handler.execute(controllerContext);
+    boolean executed = handler.execute(controllerContext);
 
-      String encodedPreviousPage = URLEncoder.encode("/portal/home", StandardCharsets.UTF_8);
-      verify(httpResponse).sendRedirect("/portal/classic/terms-and-conditions?redirect=" + encodedPreviousPage);
-      assertTrue(executed);
-    }
+    String expectedRedirect = "/portal/classic/terms-and-conditions?redirect=" +
+            URLEncoder.encode("/portal/home", StandardCharsets.UTF_8);
+    verify(httpResponse).sendRedirect(expectedRedirect);
+    assertTrue(executed);
   }
 
   @Test
   void testAnonymousUser() throws Exception {
     when(controllerContext.getRequest()).thenReturn(httpRequest);
-    when(controllerContext.getResponse()).thenReturn(httpResponse);
     when(httpRequest.getRemoteUser()).thenReturn(null);
 
-    handler.onInit(webAppController, servletConfig);
     boolean executed = handler.execute(controllerContext);
 
     verify(httpResponse, never()).sendRedirect(anyString());
-    assertFalse(executed);
+    Assertions.assertFalse(executed);
+  }
+
+  @Test
+  void testExcludedUris() throws Exception {
+    when(controllerContext.getRequest()).thenReturn(httpRequest);
+    when(httpRequest.getRequestURI()).thenReturn("/api/public/endpoint");
+
+    Field excludedUrisField = TermsAndConditionsHandler.class.getDeclaredField("excludedUris");
+    excludedUrisField.setAccessible(true);
+    excludedUrisField.set(handler, List.of("/api/public"));
+
+    boolean executed = handler.execute(controllerContext);
+
+    verify(httpResponse, never()).sendRedirect(anyString());
+    Assertions.assertFalse(executed);
   }
 }


### PR DESCRIPTION
Prevent having a loop redirection in `termsAndCondtions` web handler by adding a parameterized `excludedUris` in the handler
