### PR TITLE
fix: TermsAndCondition redirection issue when defined handler has empty excludedUris param - EXO-78278 - Meeds-io/meeds#3216

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/handler/TermsAndConditionsHandler.java
+++ b/notes-service/src/main/java/io/meeds/notes/handler/TermsAndConditionsHandler.java
@@ -60,6 +60,7 @@ public class TermsAndConditionsHandler extends WebRequestHandler {
 
   @PostConstruct
   public void init() {
+    excludedUris.removeIf(String::isBlank);
     webAppController.register(this);
   }
 


### PR DESCRIPTION
TermsAndCondition redirection issue when defined handler has empty excludedUris param
fixes - Meeds-io/meeds#3216