### PR TITLE
fix: Blank Notes version history - MEED-8509 - Meeds-io/meeds#3029

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -381,7 +381,7 @@ export default {
       exportId: 0,
       popStateChange: false,
       iframelyOriginRegex: /^https?:\/\/if-cdn.com/,
-      selectedTranslation: {value: eXo.env.portal.language},
+      selectedTranslation: { value: null, text: this.$t('notes.label.translation.originalVersion') },
       translations: [],
       languages: [],
       slectedLanguage: null,
@@ -869,15 +869,13 @@ export default {
       clearInterval(this.intervalId);
     },
     getNoteById(noteId, source, viewNote) {
-      return this.$notesService.getNoteById(noteId,this.selectedTranslation.value, source, this.noteBookType, this.noteBookOwner).then(data => {
+      return this.$notesService.getNoteById(noteId,this.targetLang, source, this.noteBookType, this.noteBookOwner).then(data => {
         this.note = data || {};
         this.isDraft = data.draftPage;
         this.loadData = true;
         this.currentNoteBreadcrumb = this.note.breadcrumb;
         this.getNoteLanguages(noteId);
-        if (!this.note.lang || this.note.lang === ''){
-          this.updateSelectedTranslation(this.originalVersion);
-        }
+        this.selectedTranslation = this.note.lang ? { value: this.targetLang } : this.originalVersion;
         this.updateURL();
         if (viewNote){
           this.viewNoteStatistics(this.note);
@@ -1019,9 +1017,9 @@ export default {
     getNoteVersionByNoteId(noteId) {
       this.noteVersionsArray = [];
       this.noteVersions = [];
-      return this.$notesService.getNoteVersionsByNoteId(noteId,this.selectedTranslation.value).then(data => {
+      return this.$notesService.getNoteVersionsByNoteId(noteId, this.selectedTranslation?.value).then(data => {
         this.noteVersions = data && data.reverse() || [];
-        if (this.noteVersions.length>0){
+        if (this.noteVersions.length) {
           this.displayVersion(this.noteVersions[0]);
           this.$root.$emit('version-restored', this.noteVersions[0]);
         }


### PR DESCRIPTION
Prior to this change, versionHistory was fetched by current user lang even if its not selected or the user hasn't added a version for target lang, which causes an empty version history drawer as it was fetched by non exiting versions lang.
This PR makes sure to correctly fetch version by adjusted targetLang
fixes Meeds-io/meeds#3029
