### PR TITLE
fix: Unable to edit notes title when its content has the navigation inserted - MEED-8754 - Meeds-io/meeds#2844

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -631,9 +631,7 @@ export default {
             this.savingDraft = false;
           }, this.autoSaveDelay/2);
         } else {
-          if (!this.isDefaultContent(this.note.content)) {
-            this.persistDraftNote(draftNote,update);
-          }
+          this.persistDraftNote(draftNote, update);
         }
       } else if (!this.newTranslation) {
         // delete draft
@@ -779,24 +777,6 @@ export default {
     enableClickOnce() {
       this.postingNote = false;
       this.postKey++;
-    },
-    isDefaultContent(noteContent) {
-      const div = document.createElement('div');
-      div.innerHTML = noteContent;
-      if ( div.childElementCount === 2) {
-        const childrenWrapper = this.editor.window.$.document.getElementById('note-children-container');
-        if ( childrenWrapper ) {
-          if (childrenWrapper.nextElementSibling.innerText.trim().length === 0) {
-            return true;
-          } else {
-            return false;
-          }
-        } else {
-          return false;
-        }
-      } else {
-        return false;
-      }
     },
     getNoteLanguages() {
       const noteId = !this.note.draftPage ? this.note.id : this.note.targetPageId;

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -248,7 +248,9 @@ export default {
     instanceReady() {
       if (this.instanceReady) {
         this.$emit('editor-ready', this.editor);
-        this.bindNavigationRemoveListener();
+        setTimeout(() => {
+          this.bindNavigationRemoveListener();
+        }, 1000);
       }
     }
   },
@@ -509,20 +511,7 @@ export default {
             self.waitUserTyping(self);
             self.noteObject.content = evt.editor.getData();
             self.autoSave();
-            const removeTreeviewBtn =  evt.editor.document.getById( 'remove-treeview' );
-            if (removeTreeviewBtn) {
-              evt.editor.editable().attachListener(removeTreeviewBtn, 'click', function() {
-                const treeviewParentWrapper = evt.editor.document.getById( 'note-children-container' );
-                if ( treeviewParentWrapper) {
-                  const newLine = treeviewParentWrapper.getNext();
-                  treeviewParentWrapper.remove();
-                  if ( newLine.$.innerText.trim().length === 0) {
-                    newLine.remove();
-                  }
-                  self.noteObject.content = evt.editor.getData();
-                }
-              });
-            }
+            self.bindNavigationRemoveListener();
           },
           doubleclick: function(evt) {
             const element = evt.data.element;
@@ -623,17 +612,35 @@ export default {
     },
     bindNavigationRemoveListener() {
       const removeTreeviewBtn = this.editor.document.getById('remove-treeview');
-      if (removeTreeviewBtn) {
-        const self = this;
-        this.editor.editable().attachListener(removeTreeviewBtn, 'click', function () {
-          const treeviewParentWrapper = self.editor.document.getById('note-children-container');
-          if (treeviewParentWrapper) {
-            treeviewParentWrapper.remove();
-            self.noteObject.content = self.editor.getData();
-          }
-          self.setFocus();
-        });
+      if (!removeTreeviewBtn) {
+        return;
       }
+      this.editor.editable().attachListener(removeTreeviewBtn, 'click', () => {
+        const treeviewParentWrapper = this.editor.document.getById('note-children-container');
+        if (treeviewParentWrapper) {
+          treeviewParentWrapper.remove();
+        }
+        const newContent = this.editor.getData().trim();
+        const isEmpty = !newContent || /^(<p>(&nbsp;|\s|<br\s*\/?>)*<\/p>)?$/.test(newContent);
+        if (isEmpty) {
+          this.editor.setData('<p><br>&nbsp;</p>', {
+            callback: () => {
+              this.editor.setReadOnly(false);
+              const editable = this.editor.editable();
+              const range = this.editor.createRange();
+              const firstElement = editable.getChildren().getItem(0);
+              range.moveToPosition(firstElement, CKEDITOR.POSITION_BEFORE_START);
+              this.editor.getSelection().selectRanges([range]);
+              this.noteObject.content = this.editor.getData();
+              this.setFocus();
+              this.editor.fire('contentDom', { type: 'contentChanged' });
+            }
+          });
+        } else {
+          this.noteObject.content = newContent;
+          this.setFocus();
+        }
+      });
     }
   }
 };


### PR DESCRIPTION
The note title becomes uneditable when the navigation content (ToC) is inserted because a check prevents persisting the navigation content, treating it as default content. This check is unnecessary, as the navigation content will be persisted when additional content is added to the same page alongside the ToC. Instead, this check is blocking draft saving when only the note title is updated.
This PR Removes the check preventing the persistence of navigation content, allowing the note title to be edited and draft saving to function correctly, even when the navigation content is present.
