### PR TITLE
fix: Error when saving content block containing an at sign (@) character - MEED-8749 - Meeds-io/meeds#3185

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -758,6 +758,9 @@ public class Utils {
   }
 
   public static void sendMentionInNoteNotification(Page note, Page originalNote, String currentUser) {
+    if (note.getAuthor() == null) {
+      return;
+    }
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
     Space space = spaceService.getSpaceByGroupId(note.getWikiOwner());

--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/config.js
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/ckeditor/config.js
@@ -77,7 +77,7 @@ CKEDITOR.editorConfig = function (config) {
   if (!webPageNote) {
     mobileToolbar[mobileToolbar.findIndex(item => item.name ==='blocks')].items.push('attachFile');
   }
-  let extraPlugins = `a11ychecker,balloonpanel,indent,indentblock,indentlist,codesnippet,sharedspace,copyformatting,table,tabletools,embedsemantic,autolink,colordialog${!webPageNote && ',tagSuggester' || ''},emoji,link,font,justify,widget,${!webPageNote && ',insertOptions' || ''},contextmenu,tabletools,tableresize,toc,linkBalloon,suggester,image2,insertImage`;
+  let extraPlugins = `a11ychecker,balloonpanel,indent,indentblock,indentlist,codesnippet,sharedspace,copyformatting,table,tabletools,embedsemantic,autolink,colordialog,emoji,link,font,justify,widget${!webPageNote && ',insertOptions,suggester,tagSuggester' || ''},contextmenu,tabletools,tableresize,toc,linkBalloon,image2,insertImage`;
   let removePlugins = `image,confirmBeforeReload,maximize,resize,autoembed${webPageNote && ',tagSuggester' || ''}`;
 
   require(['SHARED/extensionRegistry'], function(extensionRegistry) {


### PR DESCRIPTION
Prior to this change, saving a content block containing an at sign (@) would trigger the mention suggester plugin, which attempts to parse usernames and send mention notifications. However, the author attribute was null during this process, leading to errors when trying to resolve the author's identity.
This PR disables the suggester plugin in such cases and prevents sending mention notifications when the author is null.