### PR TITLE
fix: Can't search a note if it contains hyphen or apostrophe char - MEED-8795 - Meeds-io/meeds#3219.

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticSearchServiceConnector.java
@@ -197,9 +197,7 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
     } else {
     List<String> termsQuery = Arrays.stream(termQuery.split(" ")).filter(StringUtils::isNotBlank).map(word -> {
       word = word.trim();
-      if (word.length() > 5) {
-        word = word + "~1";
-      }
+      word = word + "*";
       return word;
     }).toList();
       return SEARCH_QUERY_TERM.replace("@term@", StringUtils.join(termsQuery, " "));
@@ -241,7 +239,11 @@ public class WikiElasticSearchServiceConnector extends ElasticSearchServiceConne
 
   private String removeSpecialCharacters(String string) {
     string = Normalizer.normalize(string, Normalizer.Form.NFD);
-    string = string.replaceAll("[\\p{InCombiningDiacriticalMarks}]", "").replace("'", " ");
+    string = string.replaceAll("[\\p{InCombiningDiacriticalMarks}]", "");
+    string = string.replace("''", "'");
+    if (!string.contains("\"\\")) {
+      string = string.replace("\\-", "\\\"\\\\-\\\"");
+    }
     return string;
   }
 


### PR DESCRIPTION
Before this change, when create a note with title and content containing hyphen char or apostrophe then type in unified search the note by its title or a word from its content having the hyphen/apostrophe chars, no result is displayed if the hyphen is removed from the searched expression you'll get a result. To fix this problem, escape the hyphen caracartaire and replace the double apostrophe with a single apostrophe. After this change, searching for notes in unified search is done correctly with hyphen char or apostrophe.