### PR TITLE
fix: Allow target attribute in sanitized content view - MEED-8796 - Meeds-io/meeds#3176

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageView.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageView.vue
@@ -39,6 +39,7 @@ export default {
       const pageContent = this.$root.pageContent && this.$noteUtils.getContentToDisplay(this.$root.pageContent) || '';
       const sanitizedContent = DOMPurify.sanitize(pageContent, {
         ADD_TAGS: ['iframe'],
+        ADD_ATTR: ['target'],
         tagNameCheck: () => true,
         attributeNameCheck: () => true,
       });


### PR DESCRIPTION


Prior to this change, adding a link with a target attribute in the single note view would not respect the target behavior when clicked. This issue was caused by DOMPurify disallowing the target attribute. This change allows the target attribute to be preserved during sanitization.
Resolves https://github.com/Meeds-io/meeds/issues/3222

