### PR TITLE
fix: Prevent pasted user profile link from being converted to a mention on edit - MEED-8757 - Meeds-io/meeds#2675

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -620,7 +620,7 @@ export default {
     },
     replaceWithSuggesterClass(message) {
       const tempdiv = $('<div class=\'temp\'/>').html(message || '');
-      tempdiv.find('a[href*="/profile"]')
+      tempdiv.find('a[href*="/profile"].user-suggester')
         .each(function() {
           $(this).replaceWith(function() {
             return $('<span/>', {


### PR DESCRIPTION
Prior to this change, pasted user profile links in the note/news editor were converted into mention elements in edit mode. The issue was that the process for replacing mentioned users with suggester elements replaced all links containing /profile. This change ensures that only links with the user-suggester class are replaced.
Resolves https://github.com/Meeds-io/meeds/issues/2675
