### PR TITLE
fix: Insert home note into first draft note not working - MEED-8890 -Meeds-io/meeds#2937

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/JsonNodeData.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/JsonNodeData.java
@@ -120,6 +120,8 @@ public class JsonNodeData {
       if (this.isDraftPage) {
         this.targetPageId = ((DraftPage) page).getTargetPageId();
       }
+    } else if (treeNode.getNodeType().equals(TreeNodeType.WIKIHOME)) {
+      this.url = ((WikiHomeTreeNode) treeNode).getWikiHome().getUrl();
     }
   }
 

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -53,6 +53,7 @@
       @editor-closed="editorClosed" />
     <note-treeview-drawer
       ref="noteTreeview"
+      :settings="{isEditMode: true}"
       @closed="closePluginsDrawer()" />
     <div
       v-for="(extension, i) in noteEditorExtensions"

--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
@@ -598,6 +598,9 @@ export default {
     },
     currentSpaceDisplayName() {
       return this.settings?.spaceDisplayName || this.spaceDisplayName;
+    },
+    isEditMode() {
+      return this.settings?.isEditMode ?? false;
     }
   },
   watch: {
@@ -762,7 +765,9 @@ export default {
     },
     openNote(event, note) {
       const noteIdParam = new URLSearchParams(window.location.search).get('noteId');
-      const canOpenNote = (this.filter !== this.$t('notes.filter.label.drafts') || this.filter === this.$t('notes.filter.label.drafts') && note.draftPage) && (noteIdParam ?? this.note.id) !== note.noteId;
+      const isEditDifferentNote = this.isEditMode && noteIdParam !== note.noteId;
+      const isNotCurrentNote = this.note.id !== note.noteId;
+      const canOpenNote = (this.filter !== this.$t('notes.filter.label.drafts') || this.filter === this.$t('notes.filter.label.drafts') && note.draftPage) && isEditDifferentNote || isNotCurrentNote;
       if (canOpenNote) {
         //reinitialize filter
         this.filter = this.filterOptions[0];

--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
@@ -761,7 +761,8 @@ export default {
       this.close();
     },
     openNote(event, note) {
-      const canOpenNote = (this.filter !== this.$t('notes.filter.label.drafts') || this.filter === this.$t('notes.filter.label.drafts') && note.draftPage) && note.noteId !== this.note.id;
+      const noteIdParam = new URLSearchParams(window.location.search).get('noteId');
+      const canOpenNote = (this.filter !== this.$t('notes.filter.label.drafts') || this.filter === this.$t('notes.filter.label.drafts') && note.draftPage) && (noteIdParam ?? this.note.id) !== note.noteId;
       if (canOpenNote) {
         //reinitialize filter
         this.filter = this.filterOptions[0];


### PR DESCRIPTION
Prior to this change, inserting the home note into a first draft note did not work because the insert action checked if it was in the same note. When opening the editor to create a new note under the home note, the current note was still the home. This change correctly checks for the opened note, resolving the issue.
Resolves https://github.com/Meeds-io/meeds/issues/2936