### PR TITLE
Fix: Original note summary displayed instead of the translated version in note overview - MEED-8961 - Meeds-io/meeds#3262

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -1154,6 +1154,8 @@ export default {
           this.note.title = note.title;
           this.note.latestVersionId = note.latestVersionId;
           this.noteTitle = !this.note.parentPageId && this.note.title==='Home' ? `${this.$t('notes.label.noteHome')}` : this.note.title;
+          this.note.properties = note?.properties;
+          this.noteSummary = note?.properties?.summary;
         }
         this.updateURL();
         this.getNoteVersionByNoteId(this.note.id);


### PR DESCRIPTION
Prior to this change, navigating between note translations always displayed the original note summary. This issue was caused by a missing update of the current note object's properties. This change ensures that the current note object is properly updated.
Resolves https://github.com/Meeds-io/meeds/issues/3262
