### PR TITLE
fix: Set a suitable alt to images of published article - MEED-9198 - Meeds-io/meeds#3363

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/model/NoteFeaturedImage.java
+++ b/notes-service/src/main/java/io/meeds/notes/model/NoteFeaturedImage.java
@@ -53,13 +53,15 @@ public class NoteFeaturedImage implements Serializable {
                            String mimeType,
                            long fileSize,
                            Long lastUpdated,
-                           InputStream fileInputStream) {
+                           InputStream fileInputStream,
+                           String altText) {
     this.id = id;
     this.fileName = fileName;
     this.mimeType = mimeType;
     this.fileSize = fileSize;
     this.lastUpdated = lastUpdated;
     this.fileInputStream = fileInputStream;
+    this.altText = altText;
   }
 
   public NoteFeaturedImage(Long id,

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1645,6 +1645,7 @@ public class NoteServiceImpl implements NoteService {
                                                             NOTE_METADATA_PAGE_OBJECT_TYPE);
     if (metadataItem != null && !MapUtils.isEmpty(metadataItem.getProperties())) {
       String featuredImageIdProp = metadataItem.getProperties().get(FEATURED_IMAGE_ID);
+      String featuredImageAltText = metadataItem.getProperties().get(FEATURED_IMAGE_ALT_TEXT);
       long noteFeaturedImageId = featuredImageIdProp != null
                                  && !featuredImageIdProp.equals("null") ? Long.parseLong(featuredImageIdProp) : 0L;
       FileItem fileItem = fileService.getFile(noteFeaturedImageId);
@@ -1659,7 +1660,8 @@ public class NoteServiceImpl implements NoteService {
                                      fileInfo.getMimetype(),
                                      fileInfo.getSize(),
                                      fileInfo.getUpdatedDate().getTime(),
-                                     fileItem.getAsStream());
+                                     fileItem.getAsStream(),
+                                     featuredImageAltText);
       }
     }
     return null;


### PR DESCRIPTION
Before this change, when create an article with image and publish it in a News list, The image of the published article in the News list has alt empty. To fix this problem, add the value of alt text to the NoteFeaturedImage class construct. After this change, the alt text of the image is displayed correctly.