### PR TITLE
fix: Set a suitable alt to images of published article - MEED-9198 - Meeds-io/meeds#3363

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/note-properties/NoteMetadataPropertiesForm.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/note-properties/NoteMetadataPropertiesForm.vue
@@ -219,6 +219,7 @@ export default {
       this.noteObject = structuredClone(this.note);
       this.hasFeaturedImageValue = this.hasFeaturedImage;
       this.summaryContent = this.currentProperties?.summary || '';
+      this.featuredImageAltText = this.currentProperties?.featuredImage?.altText || '';
     },
     propertiesUpdated() {
       const savedFeaturedImageId = this.noteObject?.properties?.featuredImage?.id;


### PR DESCRIPTION
Before this change, when create an article with image and publish it in a News list, the image of the published article in the News list has alt empty. To fix this problem, initialize the featuredImageAltText when opening the metadata drawer. After this change, the alt text of the image is displayed correctly.