### PR TITLE
fix: Fix 404 error when create or edit a note in a space having name with special chars - MEED-9252 - Meeds-io/meeds#3378

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageEdit.vue
@@ -124,8 +124,6 @@ export default {
       }
       formData.append('pageName', document.title);
       formData.append('isDraft', 'false');
-      formData.append('showMaxWindow', 'true');
-      formData.append('hideSharedLayout', 'true');
       formData.append('webPageNote', 'true');
       formData.append('webPageUrl', eXo?.env?.portal?.webPageUrl || `${window.location.pathname}${window.location.search || ''}`);
       if (this.note?.lang) {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -788,7 +788,7 @@ export default {
     },
     addNote() {
       if (!this.hasDraft) {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&spaceName=${eXo.env.portal?.spaceDisplayName}&appName=${this.appName}&showMaxWindow=true&hideSharedLayout=true`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}`, '_blank');
       }
     },
     editNote() {
@@ -796,7 +796,7 @@ export default {
       if (this.selectedTranslation.value){
         translation = `&translation=${this.selectedTranslation.value}`;
       }
-      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}&parentNoteId=${this.note.parentPageId ? this.note.parentPageId : this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&spaceName=${eXo.env.portal?.spaceDisplayName}&appName=${this.appName}&isDraft=${this.isDraft}&showMaxWindow=true&hideSharedLayout=true${translation}&spaceId=${eXo.env.portal.spaceId}`, '_blank');
+      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}${translation}&spaceGroupId=${eXo.env.portal?.spaceGroup}&isDraft=${this.isDraft}`, '_blank');
     },
     deleteNote() {
       if (this.hasDraft) {

--- a/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/components/TermsAndConditionsDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/components/TermsAndConditionsDrawer.vue
@@ -197,8 +197,6 @@ export default {
         formData.append('spaceGroupId', eXo.env.portal?.spaceGroup);
       }
       formData.append('isDraft', 'false');
-      formData.append('showMaxWindow', 'true');
-      formData.append('hideSharedLayout', 'true');
       if (this.note?.lang) {
         formData.append('translation', this.lang);
       }


### PR DESCRIPTION
Prior to this change, when creating or editing a note in a space having name with special chars, a 404 error is displayed instead of notes editor page, this is due to the space name invalid chars displayed on the url not accepted by RFC 7230 and RFC 3986 standard. To fix that, we will clean the create and edit note urls in order to keep only needed params.

Resolves https://github.com/Meeds-io/meeds/issues/3378

(cherry picked from commit a4081f4b07b1ff3d25b4f39d5326755e03114413)