### PR TITLE
fix: Fix create, update and restore a note with numeric title - MEED-8960 - Meeds-io/meeds#3263

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -505,10 +505,6 @@ public class NotesRestService implements ResourceContainer {
     if (note == null) {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
-    if (NumberUtils.isNumber(note.getTitle())) {
-      LOG.warn("Note's title should not be number");
-      return Response.status(Response.Status.BAD_REQUEST).entity("{ message: Note's title should not be number}").build();
-    }
     String noteBookType = note.getWikiType();
     String noteBookOwner = note.getWikiOwner();
     try {
@@ -567,10 +563,6 @@ public class NotesRestService implements ResourceContainer {
                             DraftPageEntity draftNoteToSave) {
     if (draftNoteToSave == null) {
       return Response.status(Response.Status.BAD_REQUEST).build();
-    }
-    if (NumberUtils.isDigits(draftNoteToSave.getTitle())) {
-      LOG.warn("Draft Note's title should not be number");
-      return Response.status(Response.Status.BAD_REQUEST).entity("{ message: Draft Note's title should not be number}").build();
     }
     String noteBookType = draftNoteToSave.getWikiType();
     String noteBookOwner = draftNoteToSave.getWikiOwner();
@@ -661,10 +653,6 @@ public class NotesRestService implements ResourceContainer {
     if (note == null) {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
-    if (NumberUtils.isNumber(note.getTitle())) {
-      LOG.warn("Note's title should not be number");
-      return Response.status(Response.Status.BAD_REQUEST).entity("{ message: Note's title should not be number}").build();
-    }
     try {
       if (noteBookType.toUpperCase().equals(WikiType.GROUP.name())) {
         noteBookOwner = formatWikiOwnerToGroupId(noteBookOwner);
@@ -730,11 +718,6 @@ public class NotesRestService implements ResourceContainer {
                                    @RequestBody(description = "note object to be updated", required = true) PageEntity note) {
     if (note == null) {
       return Response.status(Response.Status.BAD_REQUEST).build();
-    }
-
-    if (NumberUtils.isNumber(note.getTitle())) {
-      LOG.warn("Note's title should not be number");
-      return Response.status(Response.Status.BAD_REQUEST).entity("{ message: Note's title should not be number}").build();
     }
     try {
       Identity identity = ConversationState.getCurrent().getIdentity();
@@ -869,11 +852,6 @@ public class NotesRestService implements ResourceContainer {
   Page note) {
     if (note == null) {
       return Response.status(Response.Status.BAD_REQUEST).build();
-    }
-
-    if (NumberUtils.isNumber(note.getTitle())) {
-      LOG.warn("Note's title should not be number");
-      return Response.status(Response.Status.BAD_REQUEST).entity("{ message: Note's title should not be number}").build();
     }
     try {
       Identity identity = ConversationState.getCurrent().getIdentity();


### PR DESCRIPTION

Prior to this change, it is not possible to create, update and restore a note with numeric title due to a restriction in corresponding rest services. After this change, since this is allowed for contents, an alignment should be done in order to allow that also for notes by removing the rest services restriction.

Resolves https://github.com/Meeds-io/meeds/issues/3263