### PR TITLE
fix: Rely on Statistic Collection JS included in Bottom End Container - MEED-9310 - Meeds-io/meeds#3423

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/dynamic-container-configuration.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/dynamic-container-configuration.xml
@@ -163,53 +163,6 @@
         </object-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
-      <name>addPlugin</name>
-      <set-method>addPlugin</set-method>
-      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
-      <description></description>
-      <init-params>
-        <value-param>
-          <name>priority</name>
-          <value>5</value>
-        </value-param>
-        <value-param>
-          <name>containerName</name>
-          <value>top-notes-editor-container</value>
-        </value-param>
-        <object-param>
-          <name>statistics-portlet</name>
-          <description></description>
-          <object type="org.exoplatform.commons.addons.PortletModel">
-            <field name="contentId">
-              <string>analytics/StatisticsCollection</string>
-            </field>
-            <field name="permissions">
-              <collection type="java.util.ArrayList">
-                <value>
-                  <string>*:/platform/users</string>
-                </value>
-                <value>
-                  <string>*:/platform/externals</string>
-                </value>
-              </collection>
-            </field>
-            <field name="title">
-              <string>Statistics Collection Portlet</string>
-            </field>
-            <field name="showInfoBar">
-              <boolean>false</boolean>
-            </field>
-            <field name="showApplicationState">
-              <boolean>false</boolean>
-            </field>
-            <field name="showApplicationMode">
-              <boolean>false</boolean>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
 
   <component-plugin>
     <name>addPlugin</name>

--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/dynamic-container-configuration.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/dynamic-container-configuration.xml
@@ -116,53 +116,6 @@
         </object-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
-      <name>addPlugin</name>
-      <set-method>addPlugin</set-method>
-      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
-      <description></description>
-      <init-params>
-        <value-param>
-          <name>priority</name>
-          <value>1</value>
-        </value-param>
-        <value-param>
-          <name>containerName</name>
-          <value>notes-editor-container</value>
-        </value-param>
-        <object-param>
-          <name>notes-editor-portlet</name>
-          <description></description>
-          <object type="org.exoplatform.commons.addons.PortletModel">
-            <field name="contentId">
-              <string>notes/NotesEditor</string>
-            </field>
-            <field name="permissions">
-              <collection type="java.util.ArrayList">
-                <value>
-                  <string>*:/platform/users</string>
-                </value>
-                <value>
-                  <string>*:/platform/externals</string>
-                </value>
-              </collection>
-            </field>
-            <field name="title">
-              <string>Notes Editor Application</string>
-            </field>
-            <field name="showInfoBar">
-              <boolean>false</boolean>
-            </field>
-            <field name="showApplicationState">
-              <boolean>false</boolean>
-            </field>
-            <field name="showApplicationMode">
-              <boolean>false</boolean>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
 
   <component-plugin>
     <name>addPlugin</name>


### PR DESCRIPTION
Prior to this change, the Statistic Collections JS was injected in Notes Editor standalone page only while it should have been added in all Standalone Pages. This change will delete the declaration of StatisticCollection JS Module which is already defined in Body End Container to be included in all pages automatically.