### PR TITLE
fix: Fix note page auto translation - MEED-9351 - Meeds-io/meeds#3445

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -140,7 +140,7 @@
               </span>
               <span>
                 <notes-translation-menu
-                  note="note"
+                  :note="note"
                   :translations="translations"
                   :selected-translation="selectedTranslation"
                   @change-translation="changeTranslation" />


### PR DESCRIPTION

Prior to this change, when auto translating a note page, the title is displayed undefined and the content is not translated at all. This is due to the note prop value passed as a String not as variable from parent component. After this commit, we ensure to pass correctly the needed note prop value in order to perform the auto translation successfully.

Resolves Meeds-io/meeds#3445