### PR TITLE
fix: can't update existing note by import in same space - meed-9396 - meeds-io/meeds#3469

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -2084,7 +2084,7 @@ import static io.meeds.notes.service.TermsAndConditionsService.TC_NOTE_TYPE;
             targetNote = note_;
           }
           if (conflict.equals("duplicate")) {
-            note_ = createNote(wiki, parent_.getName(), note, userIdentity, false, true);
+            note_ = createNote(wiki, parent_.getName(), note, userIdentity, true, true);
             targetNote = note_;
           }
           if (conflict.equals("update")) {


### PR DESCRIPTION
Before this change, when try to import a note and from Import rules choose update existing notes and duplicate existing notes then click on import, the note is not imported and error popup is displayed. To fix this problem, when creating note change pass importMode as value equal to true to create another name. After this change, the note is imported.