### PR TITLE
fix: Fix check restricted audience when selecting all targets for publishing - MEED-9398 - Meeds-io/meeds#3466 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-publication/components/publish-option/NotePublishOption.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-publication/components/publish-option/NotePublishOption.vue
@@ -266,6 +266,7 @@ export default {
     },
     selectAllTargets() {
       this.selectedTargets = this.allTargetsSelected && [...this.allowedTargets] || [];
+      this.checkRestrictedAudience();
     },
     clearInputFilter() {
       this.$refs.targets.internalSearch = '';


### PR DESCRIPTION
Prior to this change, when publishing an article, the audience is set to all users and all targets are selected, the audience value is not calculated and updated according to then restricted audience of each all selected targets. After this commit, we ensure the check restricted audience when selecting all targets in order to get the audience switched to space if one of the targets has restricted audience.

Resolves Meeds-io/meeds#3466
