### PR TITLE
fix: Problem with hours selection when publishing - MEED-9451 - meeds-io/meeds#3492

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-publication/components/schedule-option/NoteScheduleOption.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-publication/components/schedule-option/NoteScheduleOption.vue
@@ -478,6 +478,8 @@ export default {
         const hours = today.getHours() + Math.floor(roundedMinutes / 60);
         const adjustedMinutes = roundedMinutes % 60;
         this.minStartTime = `${hours.toString().padStart(2, '0')}:${adjustedMinutes.toString().padStart(2, '0')}`;
+      } else {
+        this.minStartTime = '';
       }
       this.startDateMenu = false;
       this.updateEndMinTime();
@@ -487,16 +489,22 @@ export default {
     updateEndMinTime() {
       const selectedDate = new Date(this.endDate);
       const startDate = new Date(this.startDate);
-      if (!this.isUntilScheduleType && selectedDate.toDateString() === startDate.toDateString()) {
-        const [hours, minutes] = this.startTime.split(':').map(Number);
-        this.minEndTime = `${hours.toString().padStart(2, '0')}:${(minutes + 15).toString().padStart(2, '0')}`;
-      } else if (this.isUntilScheduleType) {
+      if (!this.isUntilScheduleType) {
+        if (selectedDate.toDateString() === startDate.toDateString()) {
+          const [hours, minutes] = this.startTime.split(':').map(Number);
+          this.minEndTime = `${hours.toString().padStart(2, '0')}:${(minutes + 15).toString().padStart(2, '0')}`;
+        } else {          
+          this.minEndTime = '';
+        }
+      } else {
         const today = new Date();
         if (selectedDate.toDateString() === today.toDateString()) {
           const roundedMinutes = Math.ceil(today.getMinutes() / 15) * 15;
           const hours = today.getHours() + Math.floor(roundedMinutes / 60);
           const adjustedMinutes = roundedMinutes % 60;
           this.minEndTime = `${hours.toString().padStart(2, '0')}:${adjustedMinutes.toString().padStart(2, '0')}`;
+        } else {
+          this.minEndTime = '';
         }
       }
       this.endDateMenu = false;


### PR DESCRIPTION
before this change, when request to publish, select Schedule and update the date from current day +1 to current day then update it again to choose another date, The hour is restricted to the one you can use for the current day. To fix this problem, reset minStartTime and minEndTime if the selected date is no longer today. After this change, if the selected day is not the current one, then it must be possible to select any hour.