### PR TITLE
fix: T&C should not be displayed when they are not published - MEED-9497 - Meeds-io/meeds#3516 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-user-settings/components/TermsAndConditionsUserSettings.vue
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-user-settings/components/TermsAndConditionsUserSettings.vue
@@ -72,7 +72,7 @@ export default {
       }
     });
     document.addEventListener('showSettingsApps', () => {
-      this.displayed = true;
+      this.checkTermsAndConditionsPublished();
     });
     this.checkTermsAndConditionsPublished().then(() => {
       this.handleHashChange();


### PR DESCRIPTION
Before this change, terms and conditions are displayed in the user settings when they were not published. This change will fix this issue by checking whether the terms and conditions are published or not when displaying the settings.

