### PR TITLE
fix: Notes cannot be saved if the title has less than 3 chars - MEED-9540 - meeds-io/meeds#3500

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -143,7 +143,7 @@ export default {
                                 && !this.propertiesModified && !this.draftNote && !this.note.draftPage) || this.savingDraft;
     },
     notValidTitle() {
-      return !this.webPageNote && (!this.note?.title || this.note?.title?.length < 3 || this.note?.title?.length > this.titleMaxLength);
+      return !this.webPageNote && (!this.note?.title || this.note?.title?.length < 1 || this.note?.title?.length > this.titleMaxLength);
     },
     noteNotModified() {
       return this.note?.title === this.originalNote?.title && this.$noteUtils.isSameContent(this.note?.content, this.originalNote?.content);


### PR DESCRIPTION
before this change, when got to notes app and create new notes which title has one char, notes can never be saved. To fix this problem, change the title validation condition from minimum 3 to 1. After this change, notes page is able to be saved if it is not empty.
