### PR TITLE
fix: Fix suggester in news editor - MEED-9526 - Meeds-io/meeds#3536

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -198,6 +198,14 @@ export default {
       type: String,
       default: null
     },
+    suggesterSpaceId: {
+      type: String,
+      default: null
+    },
+    suggesterSpacePrettyName: {
+      type: String,
+      default: null
+    },
     spaceGroupId: {
       type: String,
       default: null
@@ -446,6 +454,8 @@ export default {
         allowedContent: true,
         typeOfRelation: 'mention_activity_stream',
         spaceURL: self.suggesterSpaceUrl,
+        spacePrettyName: self.suggesterSpacePrettyName,
+        spaceId: self.suggesterSpaceId,
         spaceGroupId: self.spaceGroupId,
         imagesDownloadFolder: self.imagesDownloadFolder,
         toolbarLocation: 'top',


### PR DESCRIPTION
This change will fix suggester in news editor after renaming a space.

(cherry picked from commit 3fe060ef330fdb79ba95a906a63c344ea0732e6a)