### PR TITLE
fix: Move Profiles declaration from external-component-plugins - MEED-9614 - Meeds-io/meeds#3597

### DIFF
--- a/notes-service/src/main/resources/conf/portal/configuration.xml
+++ b/notes-service/src/main/resources/conf/portal/configuration.xml
@@ -198,9 +198,9 @@
     </component-plugin>
   </external-component-plugins>
 
-  <external-component-plugins profiles="gamification">
+  <external-component-plugins>
     <target-component>org.exoplatform.wiki.service.WikiService</target-component>
-    <component-plugin>
+    <component-plugin profiles="gamification">
       <name>Gamification listener for Wiki actions</name>
       <set-method>addComponentPlugin</set-method>
       <type>org.exoplatform.wiki.integration.gamification.GamificationWikiListener</type>


### PR DESCRIPTION
Prior to this change, a profiles attribute is added in '`external-component-plugins`' while it's not supported. This change will move this attribute to the compatible XML element '`component-plugin`'.

Resolves Meeds-io/meeds#3597