### PR TITLE
fix: Fix the display of searched imported notes - MEED-9762 - Meeds-io/meeds#3680

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/wikiSearch/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/wikiSearch/main.js
@@ -1,10 +1,10 @@
 import './initComponents.js';
 
 export function formatSearchResult(results,term) {
-  if (results && results.jsonList && results.jsonList.length) {
+  if (results?.jsonList?.length) {
     results = results.jsonList.map(note => {
-      note.summary = note.summary.replace(new RegExp(`(${term})`, 'ig'), '<span class="searchMatchExcerpt">$1</span>');
-      note.excerpt = note.excerpt.replace(new RegExp(`(${term})`, 'ig'), '<span class="searchMatchExcerpt">$1</span>');
+      note.summary = (note.summary || '').replace(new RegExp(`(${term})`, 'ig'), '<span class="searchMatchExcerpt">$1</span>');
+      note.excerpt = (note.excerpt || '').replace(new RegExp(`(${term})`, 'ig'), '<span class="searchMatchExcerpt">$1</span>');
       return note;
     });
   }


### PR DESCRIPTION
Prior to this change, after importing notes, when searching for them, nothing appeared although the network query returned results. This change will resolve this issue and display the search results correctly.