### PR TITLE
fix: Fix NPE when creating or opening translation notes - MEED-9815 - Meeds-io/meeds#3728

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/EntityConverter.java
@@ -578,10 +578,12 @@ public class EntityConverter {
     if (!CollectionUtils.isEmpty(metadataItems)) {
       originalNoteSharedProperties = metadataItems.getFirst().getProperties();
     }
-    return originalNoteSharedProperties.entrySet()
-                                       .stream()
-                                       .filter(entry -> ORIGINAL_SHARED_PROPERTIES.contains(entry.getKey()))
-                                       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return originalNoteSharedProperties != null ? originalNoteSharedProperties.entrySet()
+                                                                              .stream()
+                                                                              .filter(entry -> ORIGINAL_SHARED_PROPERTIES.contains(entry.getKey()))
+                                                                              .collect(Collectors.toMap(Map.Entry::getKey,
+                                                                                                        Map.Entry::getValue))
+                                                : new HashMap<>();
   }
 
   private static void buildPageProperties(Map<String, String> properties,


### PR DESCRIPTION
Prior to this change, starting from 7.0.0-M43, notes are created with metadata items of type 'notePage' but without any associated properties. When migrating to next versions, we have a NPE when trying to access or create an related translation note.
To fix that, we try to avoid the NPE by the checking metadata item properties nullability.

Resolves Meeds-io/meeds#3728

(cherry picked from commit 839aa946b899246ecc99af775edbba95b752666c)