### PR TITLE
fix: Links inserted in a note are not "reindexed" when exporting it  - MEED-9811 - Meeds-io/meeds#3701

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/ExportThread.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/ExportThread.java
@@ -19,17 +19,14 @@
 package org.exoplatform.wiki.service;
 
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,8 +45,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.wiki.service.plugin.WikiPageAttachmentPlugin;
 import org.exoplatform.wiki.utils.Utils;
 import org.springframework.util.MimeTypeUtils;
 
@@ -80,6 +75,10 @@ import io.meeds.notes.model.NotePageProperties;
   private static final String            IMAGE_URL_REPLACEMENT_PREFIX = "//-";
 
   private static final String            IMAGE_URL_REPLACEMENT_SUFFIX = "-//";
+
+   private static final String           CONTENT_LINK_TAG             = "content-link";
+
+   private static final String           CONTENT_LINK_TAG_REPLACEMENT = "--content--link-to-insert";
 
   private static final String            EXPORT_ZIP_EXTENSION         = ".zip";
 
@@ -238,6 +237,7 @@ import io.meeds.notes.model.NotePageProperties;
             noteToExport.setProperties(note.getProperties());
             noteToExport.setContent(processImagesForExport(note));
             noteToExport.setContent(processNotesLinkForExport(noteToExport));
+            noteToExport.setContent(processInsertedNotes(noteToExport.getContent()));
             LinkedList<String> ancestors = getNoteAncestorsIds(noteToExport.getId());
             noteToExport.setAncestors(ancestors);
             if (ancestors.size() > maxAncestors) {
@@ -380,7 +380,25 @@ import io.meeds.notes.model.NotePageProperties;
     }
   }
 
-  private List<NoteToExport> getBottomNotesToExport(List<NoteToExport> allNotesToExport, int level) {
+   private String processInsertedNotes(String content) throws WikiException {
+     Pattern pattern = Pattern.compile("(<)" + CONTENT_LINK_TAG + "([^>]*?>/notes:)(\\d+)(</)" + CONTENT_LINK_TAG + "(>)");
+     Matcher matcher = pattern.matcher(content);
+     StringBuilder result = new StringBuilder();
+     while (matcher.find()) {
+       String id = matcher.group(3);
+       Page note = noteService.getNoteById(id);
+       String noteName = "noteNotFound";
+       if (note != null) {
+         noteName = matcher.group(1) + CONTENT_LINK_TAG_REPLACEMENT + matcher.group(2)
+                 + note.getName() + matcher.group(4) + CONTENT_LINK_TAG_REPLACEMENT + matcher.group(5);
+       }
+       matcher.appendReplacement(result, Matcher.quoteReplacement(noteName));
+     }
+     matcher.appendTail(result);
+     return result.toString();
+   }
+
+   private List<NoteToExport> getBottomNotesToExport(List<NoteToExport> allNotesToExport, int level) {
     return allNotesToExport.stream().filter(export -> export.getAncestors().size() == level).collect(Collectors.toList());
   }
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -124,6 +124,10 @@ public class NoteServiceImpl implements NoteService {
 
   private static final String                             IMAGE_URL_REPLACEMENT_SUFFIX           = "-//";
 
+  private static final String                             CONTENT_LINK_TAG                       = "content-link";
+
+  private static final String                             CONTENT_LINK_TAG_REPLACEMENT           = "--content--link-to-insert";
+
   private static final Pattern                            IMAGES_IMPORT_PATTERN                  =
                                                                                 Pattern.compile("src=\"//-(.*?)-//\"");
 
@@ -1353,6 +1357,7 @@ public class NoteServiceImpl implements NoteService {
                    userIdentity);
       }
       for (Page note : notes.getNotes()) {
+        replaceInsertedNotes(note, wiki, userIdentity);
         replaceIncludedPages(note, wiki, userIdentity);
       }
       cleanUp(notesFile);
@@ -2098,6 +2103,38 @@ public class NoteServiceImpl implements NoteService {
     if (note.getChildren() != null) {
       for (Page child : note.getChildren()) {
         replaceIncludedPages(child, wiki, userIdentity);
+      }
+    }
+  }
+
+  private void replaceInsertedNotes(Page note, Wiki wiki, Identity userIdentity) {
+    Page note_ = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), note.getName());
+    if (note_ != null) {
+      String content = note_.getContent();
+      Pattern pattern = Pattern.compile("(<)" + CONTENT_LINK_TAG_REPLACEMENT + "([^>]*?>/notes:)([^<]+)(</)" + CONTENT_LINK_TAG_REPLACEMENT + "(>)");
+      Matcher matcher = pattern.matcher(content);
+      StringBuilder result = new StringBuilder();
+      while (matcher.find()) {
+        String noteName = matcher.group(3);
+        Page noteToInsert = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), noteName);
+        String noteId = "0";
+        if (noteToInsert != null) {
+          noteId = matcher.group(1) + CONTENT_LINK_TAG + matcher.group(2)
+                  + noteToInsert.getId() + matcher.group(4) + CONTENT_LINK_TAG + matcher.group(5);
+        }
+        matcher.appendReplacement(result, Matcher.quoteReplacement(noteId));
+      }
+      matcher.appendTail(result);
+      content = result.toString();
+      if (!content.equals(note_.getContent())) {
+        note_.setContent(content);
+        updateNote(note_);
+        createVersionOfNote(note_, userIdentity.getUserId(), true);
+      }
+    }
+    if (note.getChildren() != null) {
+      for (Page child : note.getChildren()) {
+        replaceInsertedNotes(child, wiki, userIdentity);
       }
     }
   }


### PR DESCRIPTION
Prior to this fix, when exporting and then importing a note containing an inserted link to another note. The link in the imported note is lost.
 This commit
fixes this by using the note name in the exported data, then sets the new ID during the import.