### PR TITLE
fix: Having a relevant title for notes page - MEED-9889 - meeds-io/meeds#3788.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -442,6 +442,11 @@ export default {
           }
         }
       }
+    },
+    noteTitle() {
+      const companyName = eXo.env.portal.companyName;
+      const spaceDisplayName = eXo.env.portal.spaceDisplayName;
+      window.document.title = `${this.noteTitle} - ${spaceDisplayName} - ${companyName}`;
     }
   },
   computed: {


### PR DESCRIPTION
before this change, when create several notes and access to any note of them, the page title is in this format [Page Name] - [Space Name or Site Name] - [Platform Name]. To fix this problem, change the page title when the note object is retrieved. After this change, the page title is in this format [note name] - [Space Name or Site Name] - [Platform Name].
