### PR TITLE
fix: The active page in the note tree can only be distinguished by color - MEED-9865 - meeds-io/meeds#3758. 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
@@ -425,6 +425,7 @@
                     v-else
                     :href="item.draftPage ? `${item.noteId}/draft` : item.noteId"
                     :class="{'text-color': (isDraftFilter && item.draftPage) || !item.draftPage}"
+                    :aria-current="(item.noteId === activeItem[0] && !item.draftPage) ? 'page' : null"
                     @click.prevent="openNote($event,item)">
                     {{ item.name }}
                   </a>

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
@@ -14,6 +14,7 @@
                 :id="breadcrumbItem.id"
                 :ref="breadcrumbItem.id"
                 :class="breadcrumbItem.classLink"
+                :aria-current="breadcrumbItem.id === 'lastBreadcrumbItem' ? 'page' : null"
                 v-bind="attrs"
                 v-on="on"
                 @click="openNote(noteBreadcrumb[breadcrumbItem.index])">{{ breadcrumbItem.title }}</a>


### PR DESCRIPTION
before this change, when create a note tree and access to any note in the tree, in the breacrumb the active page can only be distinguished by color and in the notes tree drawer the active page can only be distinguished by color. To fix this problem, add an aria-current property equal to a string page to the last item of these trees. After this change, In the notes breadcrumb AND int he notes tree, distinguish the active page link from other links by adding an aria-current equal to the string page property to its a href.