### PR TITLE
Fix: Having a relevant title for the notes page - MEED-9889 - meeds-io/meeds#3788.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -441,6 +441,11 @@ export default {
           }
         }
       }
+    },
+    noteTitle() {
+      const companyName = eXo.env.portal.companyName;
+      const spaceDisplayName = eXo.env.portal.spaceDisplayName;
+      window.document.title = `${this.noteTitle} - ${spaceDisplayName} - ${companyName}`;
     }
   },
   computed: {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -445,7 +445,7 @@ export default {
     noteTitle() {
       const companyName = eXo.env.portal.companyName;
       const spaceDisplayName = eXo.env.portal.spaceDisplayName;
-      window.document.title = `${this.noteTitle} - ${spaceDisplayName} - ${companyName}`;
+      window.document.title = `Note: ${this.noteTitle} - ${spaceDisplayName} - ${companyName}`;
     }
   },
   computed: {


### PR DESCRIPTION
Before this change, when creating several notes and accessing any of them, the page title was in this format: [Page Name] - [Space Name or Site Name] - [Platform Name]. To fix this problem, the page title is now changed when the note object is retrieved. After this change, the page title is in this format: Note: [note name] - [Space Name or Site Name] - [Platform Name].