### PR TITLE
fix: Can't create a task using keyboard shortcut in note or article - MEED-9860 - meeds-io/meeds#3748. 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -483,6 +483,23 @@ export default {
             self.$root.$applicationLoaded();
             self.instanceReady = true;
             self.setToolBarEffect();
+            self.editor.on('contentDom', function () {
+              const editable = self.editor.editable();
+              editable.attachListener(editable, 'keydown', function (event) {
+                const domEvent = event.data.$;
+                if (domEvent.ctrlKey && domEvent.shiftKey && domEvent.keyCode !== 16) {
+                  domEvent.preventDefault();
+                  domEvent.stopPropagation();
+                  const synthetic = new KeyboardEvent('keydown', {
+                    key: domEvent.key,
+                    ctrlKey: true,
+                    shiftKey: true,
+                    bubbles: true
+                  });
+                  window.dispatchEvent(synthetic);
+                }
+              });
+            });
           },
           change: function (evt) {
             if (!self.noteContentInitialized || self.isContentImagesUploadProgress) {

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -483,23 +483,16 @@ export default {
             self.$root.$applicationLoaded();
             self.instanceReady = true;
             self.setToolBarEffect();
+            let isAttachedKeyListener = false;
             self.editor.on('contentDom', function () {
+              isAttachedKeyListener = true;
               const editable = self.editor.editable();
-              editable.attachListener(editable, 'keydown', function (event) {
-                const domEvent = event.data.$;
-                if (domEvent.ctrlKey && domEvent.shiftKey && domEvent.keyCode !== 16) {
-                  domEvent.preventDefault();
-                  domEvent.stopPropagation();
-                  const synthetic = new KeyboardEvent('keydown', {
-                    key: domEvent.key,
-                    ctrlKey: true,
-                    shiftKey: true,
-                    bubbles: true
-                  });
-                  window.dispatchEvent(synthetic);
-                }
-              });
+              self.attachKeyListener(editable);
             });
+            if (!isAttachedKeyListener) {
+              const editable = self.editor.editable();
+              self.attachKeyListener(editable);
+            }
           },
           change: function (evt) {
             if (!self.noteContentInitialized || self.isContentImagesUploadProgress) {
@@ -529,6 +522,22 @@ export default {
               self.$emit('open-treeview', noteId, 'includePages', 'no-arrow');
             }
           }
+        }
+      });
+    },
+    attachKeyListener(editable) {
+      editable.attachListener(editable, 'keydown', function (event) {
+        const domEvent = event.data.$;
+        if (domEvent.ctrlKey && domEvent.shiftKey && domEvent.keyCode !== 16) {
+          domEvent.preventDefault();
+          domEvent.stopPropagation();
+          const synthetic = new KeyboardEvent('keydown', {
+            key: domEvent.key,
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true
+          });
+          window.dispatchEvent(synthetic);
         }
       });
     },


### PR DESCRIPTION
Before this change, when create a note/article and add a text and use the shortcut ctrl shift + to create a task then use again ctrl shift + to create a task, can't be create a task. To fix this problem, the shortcut listener was added directly to CKEditor's internal document. After this change, using task shortcut always open the task drawer so a new task could be created.