### PR TITLE
fix: Accessibility -  Breadcrumb cannot be reached  - MEED-9864 - Meeds-io/meeds#3757

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -129,6 +129,7 @@ popup.msg.confirmation.DeleteDraftInfo5=This draft is child of the note: {0}
 popup.confirmation=You are about to save an Untitled page.
 popup.confirmation.cancel=Are you sure you want to leave this page?
 notes.label.breadcrumbTitle=Notes Tree
+notes.label.breadcrumbs=Breadcrumbs
 notes.label.filter=Filter by name
 notes.label.includePageTitle=Include Notes
 notes.label.movePageTitle=Move Page

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
@@ -1,7 +1,9 @@
 <template>
   <div 
     v-if="isDesktop"
-    class="note-breadcrumb-wrapper">
+    class="note-breadcrumb-wrapper"
+    role="navigation" 
+    aria-label="Breadcrumbs">
     <div class="notes-tree-items d-flex align-center">
       <template v-for="(breadcrumbItem, index) in noteBreadcrumbList">
         <div 
@@ -9,15 +11,18 @@
           :key="index"
           :class="breadcrumbItem.class">
           <v-tooltip max-width="300" bottom>
-            <template #activator="{ on, attrs }">
+            <template #activator="{ on, filteredAttrs }">
               <a
                 :id="breadcrumbItem.id"
                 :ref="breadcrumbItem.id"
                 :class="breadcrumbItem.classLink"
                 :aria-current="breadcrumbItem.id === 'lastBreadcrumbItem' ? 'page' : null"
-                v-bind="attrs"
+                v-bind="filteredAttrs"
                 v-on="on"
-                @click="openNote(noteBreadcrumb[breadcrumbItem.index])">{{ breadcrumbItem.title }}</a>
+                tabindex="0"
+                @click="openNote(noteBreadcrumb[breadcrumbItem.index])"
+                @keydown="openNoteOnEnter($event, noteBreadcrumb[breadcrumbItem.index])">{{ breadcrumbItem.title }}
+              </a>
             </template>
             <span class="caption">{{ breadcrumbItem.title }}</span>
           </v-tooltip>
@@ -41,7 +46,8 @@
                 v-on="on"
                 class="text-sub-title"
                 size="18"
-                @click="openNote(noteBreadcrumb[noteEllipsisList[noteEllipsisList.length-1].index])">
+                @click="openNote(noteBreadcrumb[noteEllipsisList[noteEllipsisList.length-1].index])"
+                @keydown="openNoteOnEnter($event, noteBreadcrumb[noteEllipsisList[noteEllipsisList.length-1].index])">
                 fas fa-ellipsis-h
               </v-icon>
             </template>
@@ -82,6 +88,11 @@ export default {
     isDesktop() {
       return this.$vuetify.breakpoint.width >= 960;
     },
+    filteredAttrs() {
+      const attrs = { ...(this.attrs || {}) };
+      delete attrs.role;
+      return attrs;
+    }
   },
   watch: {
     noteBreadcrumb() {
@@ -116,6 +127,11 @@ export default {
         this.noteBreadcrumb = [];
         this.$emit('open-note',note.id);
         document.dispatchEvent(new CustomEvent('note-navigation-updated', {detail: note}));
+      }
+    },
+    openNoteOnEnter(event, note) {
+      if (event.key === 'Enter') {
+        this.openNote(note);
       }
     },
     initNoteBreadcrumb() {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NoteBreadcrumb.vue
@@ -3,7 +3,7 @@
     v-if="isDesktop"
     class="note-breadcrumb-wrapper"
     role="navigation" 
-    aria-label="Breadcrumbs">
+    :aria-label="$t('notes.label.breadcrumbs')">
     <div class="notes-tree-items d-flex align-center">
       <template v-for="(breadcrumbItem, index) in noteBreadcrumbList">
         <div 


### PR DESCRIPTION
Prior to this fix, notes breadcrumb are cannot be reached.
This commit resolves the accessibility issue by making the breadcrumb items focusable and adding a navigation role to the parent div.