### PR TITLE
fix: Add missing title attribute to single note view actions button - MEED-9946 - Meeds-io/meeds#3832

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/NotePageView_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/NotePageView_en.properties
@@ -1,5 +1,6 @@
 notePageView.label.addTextButton=Add text
 notePageView.placeholder.editText=Start writing your content
+notePageView.actions.title=Access options
 notePageView.label.openFullPageEditor=Access advanced editor
 notePageView.label.openFullPageWithMultiLanguage=Access advanced editors to update multilingual versions
 notePageView.label.edit=Edit

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageHeader.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageHeader.vue
@@ -38,6 +38,7 @@
         <v-btn
           :loading="loading"
           :elevation="loading && 2 || 0"
+          :title="$t('notePageView.actions.title')"
           small
           icon
           class="ma-1"


### PR DESCRIPTION
This change adds a title attribute to the single note view actions button, improving the accessibility score 