### PR TITLE
fix: Can't access button by tabbing - MEED-9937 - meeds-io/meeds#3833.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -28,9 +28,10 @@
           'overflow-hidden': edit,
         }"
         :tabindex="tabindex"
+        :ripple="false"
         min-width="100%"
         max-width="100%"
-        class="d-flex flex-column border-box-sizing position-relative application-body"
+        class="d-flex not-clickable flex-column border-box-sizing position-relative application-body"
         flat
         @focusin="onFocusIn"
         @focusout="onFocusOut">
@@ -157,11 +158,11 @@ export default {
     switchToEdit() {
       this.previewMode = false;
     },
-    onFocusIn() {
+    onFocusIn(event) {
       this.hover = true;
       this.$nextTick(() => {
         const header = this.$refs.header?.$refs?.menuBtnHeader?.$el;
-        if (header) {
+        if (header && event.relatedTarget) {
           header.focus();
           this.tabindex = '-1';
         }


### PR DESCRIPTION
Before this change, when add SNV portlet in a page and tab into the page, can't access the three button by tabbing . To fix this problem, add the focusin and focusout events to access the menu button. After this change, the three button is accessible by tabbing.