### PR TITLE
fix: Can't access button by tabbing - MEED-9937 - meeds-io/meeds#3833.

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageHeader.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageHeader.vue
@@ -36,6 +36,7 @@
       attach>
       <template #activator="{ on, attrs }">
         <v-btn
+          ref="menuBtnHeader"
           :loading="loading"
           :elevation="loading && 2 || 0"
           :title="$t('notePageView.actions.title')"

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -28,9 +28,10 @@
           'overflow-hidden': edit,
         }"
         :tabindex="tabindex"
+        :ripple="false"
         min-width="100%"
         max-width="100%"
-        class="d-flex flex-column border-box-sizing position-relative application-body"
+        class="d-flex not-clickable flex-column border-box-sizing position-relative application-body"
         flat
         @focusin="onFocusIn"
         @focusout="onFocusOut">
@@ -157,11 +158,11 @@ export default {
     switchToEdit() {
       this.previewMode = false;
     },
-    onFocusIn() {
+    onFocusIn(event) {
       this.hover = true;
       this.$nextTick(() => {
         const header = this.$refs.header?.$refs?.menuBtnHeader?.$el;
-        if (header) {
+        if (header && event.relatedTarget) {
           header.focus();
           this.tabindex = '-1';
         }

--- a/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
+++ b/notes-webapp/src/main/webapp/vue-app/note-page-view/components/NotePageViewApp.vue
@@ -21,16 +21,19 @@
 <template>
   <v-app
     v-if="canView">
-    <v-hover v-slot="{ hover }">
+    <v-hover v-model="hover">
       <v-card
         :class="{
           'pa-5': viewMode,
           'overflow-hidden': edit,
         }"
+        :tabindex="tabindex"
         min-width="100%"
         max-width="100%"
         class="d-flex flex-column border-box-sizing position-relative application-body"
-        flat>
+        flat
+        @focusin="onFocusIn"
+        @focusout="onFocusOut">
         <template v-if="edit">
           <note-page-edit-drawer
             v-if="$root.isMobile"
@@ -49,6 +52,7 @@
         <template v-if="!hideViewMode">
           <note-page-header
             v-if="displayEditMode"
+            ref="header"
             :hover="hover || editorLoading"
             :loading="editorLoading"
             @edit="openEditor" />
@@ -67,6 +71,8 @@ export default {
     edit: false,
     editorReady: false,
     previewMode: false,
+    hover: false,
+    tabindex: '0',
   }),
   computed: {
     hasNote() {
@@ -150,6 +156,25 @@ export default {
     },
     switchToEdit() {
       this.previewMode = false;
+    },
+    onFocusIn() {
+      this.hover = true;
+      this.$nextTick(() => {
+        const header = this.$refs.header?.$refs?.menuBtnHeader?.$el;
+        if (header) {
+          header.focus();
+          this.tabindex = '-1';
+        }
+      });
+    },
+    onFocusOut(event) {
+      const root = this.$el;
+      const next = event.relatedTarget;
+      if (next && root.contains(next)) {
+        return;
+      }
+      this.tabindex = '0';
+      this.hover = false;
     }
   },
 };


### PR DESCRIPTION
Before this change, when add SNV portlet in a page and tab into the page, can't access the three button by tabbing . To fix this problem, add the focusin and focusout events to access the menu button. After this change, the three button is accessible by tabbing.