### PR TITLE
fix: set parent page identifier in draft pages - MEED-9965 (#1545)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -805,7 +805,7 @@ export default {
       if (this.selectedTranslation.value){
         translation = `&translation=${this.selectedTranslation.value}`;
       }
-      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}${translation}&spaceGroupId=${eXo.env.portal?.spaceGroup}&isDraft=${this.isDraft}`, '_blank');
+      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}${translation}&spaceGroupId=${eXo.env.portal?.spaceGroup}&isDraft=${this.isDraft}&parentNoteId=${this.parentPageId}`, '_blank');
     },
     deleteNote() {
       if (this.hasDraft) {


### PR DESCRIPTION
When filtering Note pages with draft selector, child draft pages does not show up since they are saved without being linked to the parent page the change adds the parent page ID to the Notes editor parameters to be saved automatically when saving the draft page