### PR TITLE
fix: Fix updating notes home page - MEED-10031 - Meeds-io/meeds#3907 (#1557)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -229,7 +229,8 @@ export default {
       this.initActualNoteDone=true;
     }
     if (urlParams.has('parentNoteId')) {
-      this.parentPageId = urlParams.get('parentNoteId');
+      const parentNoteId = urlParams.get('parentNoteId');
+      this.parentPageId = parentNoteId === 'null' ? null : parentNoteId;
       this.spaceId = urlParams.get('spaceId');
       this.spaceGroupId  = urlParams.get('spaceGroupId');
       this.spaceDisplayName  = urlParams.get('spaceName');


### PR DESCRIPTION
update notes home page and handle parentNoteId null normalization

(cherry picked from commit ae710e820d4820fab9448d1e2770bdbbf40af498) (cherry picked from commit b5ca0f5c5470c38273276cc3a07dbcbeb3d8a015)