### PR TITLE
feat: Adapt move option for personal note - MEED-10062 - Meeds-io/MIPs#234

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
@@ -262,7 +262,7 @@
                 <v-chip
                   class="identitySuggesterItem me-2 mt-2">
                   <span class="text-truncate">
-                    {{ currentSpaceDisplayName }}
+                    {{ currentLocation }}
                   </span>
                 </v-chip>
               </div>
@@ -601,8 +601,8 @@ export default {
     showCurrentDestination() {
       return this.settings?.showCurrentDestination ?? true;
     },
-    currentSpaceDisplayName() {
-      return this.settings?.spaceDisplayName || this.spaceDisplayName;
+    currentLocation() {
+      return this.settings?.spaceDisplayName || this.spaceDisplayName || eXo.env.portal.siteLabel;
     },
     isEditMode() {
       return this.settings?.isEditMode ?? false;


### PR DESCRIPTION
This change will display site label instead of space name in move option drawer