### PR TITLE
fix: Restore the title when restoring a note- MEED-10085 - meeds-io/meeds#3943

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/model/PageHistory.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/model/PageHistory.java
@@ -40,4 +40,6 @@ public class PageHistory {
   private String content;
 
   private String lang;
+
+  private String title;
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/storage/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/storage/EntityConverter.java
@@ -319,6 +319,7 @@ public class EntityConverter {
       pageHistory.setCreatedDate(pageVersionEntity.getCreatedDate());
       pageHistory.setUpdatedDate(pageVersionEntity.getUpdatedDate());
       pageHistory.setLang(pageVersionEntity.getLang());
+      pageHistory.setTitle(pageVersionEntity.getTitle());
       if (StringUtils.isNotBlank(pageHistory.getAuthor())) {
         Identity identity = ExoContainerContext.getService(IdentityManager.class)
             .getOrCreateUserIdentity(pageHistory.getAuthor());

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -405,19 +405,22 @@ export default {
     };
   },
   watch: {
-    note() {
-      if (!this.note.draftPage) {
-        this.getNoteVersionByNoteId(this.note.id);
-      }
-      if ( this.note && this.note.breadcrumb && this.note.breadcrumb.length ) {
-        this.note.breadcrumb[0].title = this.getHomeTitle(this.note.breadcrumb[0].title);
-        this.currentNoteBreadcrumb = this.note.breadcrumb;
-      }
-      this.noteTitle = !this.note.parentPageId && this.note.title==='Home' ? `${this.$t('notes.label.noteHome')}` : this.note.title;
-      this.noteContent = this.note.content;
-      this.noteSummary = this.note?.properties?.summary;
-      if (this.hasEmptyContent || this.isHomeNoteDefaultContent) {
-        this.retrieveNoteTreeById();
+    note: {
+      deep: true,
+      handler() {
+        if (!this.note.draftPage) {
+          this.getNoteVersionByNoteId(this.note.id);
+        }
+        if ( this.note && this.note.breadcrumb && this.note.breadcrumb.length ) {
+          this.note.breadcrumb[0].title = this.getHomeTitle(this.note.breadcrumb[0].title);
+          this.currentNoteBreadcrumb = this.note.breadcrumb;
+        }
+        this.noteTitle = !this.note.parentPageId && this.note.title==='Home' ? `${this.$t('notes.label.noteHome')}` : this.note.title;
+        this.noteContent = this.note.content;
+        this.noteSummary = this.note?.properties?.summary;
+        if (this.hasEmptyContent || this.isHomeNoteDefaultContent) {
+          this.retrieveNoteTreeById();
+        }
       }
     },
     actualVersion() {
@@ -1061,16 +1064,18 @@ export default {
       this.actualVersion = version;
       this.actualVersion.current = true;
       this.note.content = version.content;
+      this.note.title = version.title;
     },
     restoreVersion(version) {
       const note = {
         id: this.note.id,
-        title: this.note.title,
+        title: version.title,
         content: version.content,
         updatedDate: version.updatedDate,
         owner: version.author
       };
       this.note.content = version.content;
+      this.note.title = version.title;
       this.$notesService.restoreNoteVersion(note,version.versionNumber)
         .catch(e => {
           console.error('Error when restore note version', e);


### PR DESCRIPTION
Before this change, when I restored a note from the history, the title was not restored. The body, title, and summary should be restored when reverting to a previous version. This change will resolve this issue.