### PR TITLE
Fix: Files no longer attached must no longer be listed - EXO-83535 - meeds-io/meeds#3961

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -738,6 +738,7 @@ public class NotesRestService implements ResourceContainer {
         featuredImage = notePageProperties.getFeaturedImage();
       }
       String newNoteName = note_.getName();
+      NotePageProperties currentNodeProperties = note_.getProperties();
       if (!note_.getTitle().equals(note.getTitle()) && !note_.getContent().equals(note.getContent())) {
         if (StringUtils.isBlank(note.getLang())) {
           newNoteName = TitleResolver.getId(note.getTitle(), false);
@@ -799,8 +800,10 @@ public class NotesRestService implements ResourceContainer {
           noteService.removeDraftOfNote(noteParams, note.getLang());
         }
       } else if (featuredImage != null && (featuredImage.isToDelete() || featuredImage.getUploadId() != null)
-          || !Objects.equals(note_.getProperties(), notePageProperties)) {
-        NotePageProperties currentNodeProperties = note_.getProperties();
+                  || !currentNodeProperties.getFeaturedImage().getId().equals(featuredImage.getId())
+                  || !StringUtils.defaultString(currentNodeProperties.getFeaturedImage().getAltText())
+                           .equals(StringUtils.defaultString(featuredImage.getAltText()))
+                  || !currentNodeProperties.getSummary().equals(notePageProperties.getSummary())) {
         if (StringUtils.isBlank(note.getLang())) {
           note_.setProperties(notePageProperties);
           note_ = noteService.updateNote(note_, PageUpdateType.EDIT_PAGE_PROPERTIES, identity);
@@ -809,13 +812,7 @@ public class NotesRestService implements ResourceContainer {
           note_.setLang(note.getLang());
           note_.setProperties(notePageProperties);
         }
-        if (featuredImage != null && (featuredImage.isToDelete() || featuredImage.getUploadId() != null)
-            || !currentNodeProperties.getFeaturedImage().getId().equals(featuredImage.getId())
-            || !StringUtils.defaultString(currentNodeProperties.getFeaturedImage().getAltText())
-                           .equals(StringUtils.defaultString(featuredImage.getAltText()))
-            || !currentNodeProperties.getSummary().equals(notePageProperties.getSummary())) {
-          noteService.createVersionOfNote(note_, identity.getUserId(), true);
-        }
+        noteService.createVersionOfNote(note_, identity.getUserId(), true);
         if (!Utils.ANONYM_IDENTITY.equals(identity.getUserId())) {
           WikiPageParams noteParams = new WikiPageParams(note_.getWikiType(), note_.getWikiOwner(), newNoteName);
           noteService.removeDraftOfNote(noteParams, note.getLang());


### PR DESCRIPTION
Before this change, when editing a note and detaching files, once the note is saved and the attachment list is reopened, these files still appeared in the list. To fix this problem, in the  method of the NotesRestService, change the condition where the note has a  to be true except when the  is modified. To do this, check  and call the  method of the NoteService. After this change, the list of results is displayed correctly.