### PR TITLE
fix: Notes attachments are not saved in space drive folder - EXO-83542 - Meeds-io/meeds#3963 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -39,6 +39,7 @@
       :publish-button-text="$t('notes.button.publish')"
       :editor-icon="editorIcon"
       :space-group-id="`/spaces/${spaceGroupId}`"
+      :target-space-id="targetSpaceId"
       :suggester-space-url="spaceGroupId"
       :save-button-icon="saveButtonIcon"
       :is-mobile="isMobile"
@@ -113,6 +114,7 @@ export default {
       navigationLabel: `${this.$t('notes.label.Navigation')}`,
       noteNavigationDisplayed: false,
       spaceGroupId: null,
+      targetSpaceId: null,
       oembedMinWidth: 300,
       selectedLanguage: null,
       translations: null,
@@ -233,6 +235,7 @@ export default {
       this.parentPageId = parentNoteId === 'null' ? null : parentNoteId;
       this.spaceId = urlParams.get('spaceId');
       this.spaceGroupId  = urlParams.get('spaceGroupId');
+      this.getTargetSpaceId(this.spaceGroupId);
       this.spaceDisplayName  = urlParams.get('spaceName');
       this.note.parentPageId = this.parentPageId;
     }
@@ -264,6 +267,14 @@ export default {
     this.$root.$on('save-draft', this.autoSave);
   },
   methods: {
+    getTargetSpaceId(groupId) {
+      if (this.spaceId || !groupId) {
+        return;
+      }
+      this.$spaceService.getSpaceByGroupId(groupId).then((space) => {
+        this.targetSpaceId = space?.id;
+      });
+    },
     processAutoSaveFromEditorExtension(event) {
       if (event.detail.processAutoSave) {
         this.extensionDataUpdated = true;

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -227,6 +227,10 @@ export default {
     publicationParams: {
       type: Object,
       default: null
+    },
+    targetSpaceId: {
+      type: Number,
+      default: null
     }
   },
   watch: {
@@ -269,7 +273,7 @@ export default {
     },
     extensionParams() {
       return {
-        spaceId: this.getURLQueryParam('spaceId'),
+        spaceId: this.getURLQueryParam('spaceId') || this.targetSpaceId,
         entityId: this.entityId,
         entityType: this.note.draftPage && 'WIKI_DRAFT_PAGES' || 'WIKI_PAGE_VERSIONS',
         lang: this.note.lang,


### PR DESCRIPTION
Note attachments were not saved in the space drive because the spaceId in the attachment app config was null. This update makes sure the config is populated with the correct spaceId.

fixes Meeds-io/meeds#3963 
