### PR TITLE
fix: Cleanup duplicated wiki entries - MEED-10114 - Meeds-io/meeds#3924

### DIFF
--- a/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
+++ b/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
@@ -455,6 +455,40 @@
       columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
+  
+  <changeSet id="1.0.0-53-clean-duplicates" author="wiki">
+    <sql>
+		DELETE FROM WIKI_PAGES
+		WHERE WIKI_ID IN (
+		  SELECT w1.WIKI_ID
+		  FROM WIKI_WIKIS w1
+		  JOIN WIKI_WIKIS w2
+			ON w1.OWNER = w2.OWNER
+		   AND w1.TYPE = w2.TYPE
+		   AND w1.WIKI_ID > w2.WIKI_ID
+		)
+       
+		DELETE FROM WIKI_TEMPLATES
+		WHERE WIKI_ID IN (
+		  SELECT w1.WIKI_ID
+		  FROM WIKI_WIKIS w1
+		  JOIN WIKI_WIKIS w2
+			ON w1.OWNER = w2.OWNER
+		   AND w1.TYPE = w2.TYPE
+		   AND w1.WIKI_ID > w2.WIKI_ID
+		)
+		
+		DELETE FROM WIKI_WIKIS
+		WHERE WIKI_ID IN (
+		  SELECT w1.WIKI_ID
+		  FROM WIKI_WIKIS w1
+		  JOIN WIKI_WIKIS w2
+			ON w1.OWNER = w2.OWNER
+		   AND w1.TYPE = w2.TYPE
+		   AND w1.WIKI_ID > w2.WIKI_ID
+		)
+    </sql>
+  </changeSet>
 
   <changeSet id="1.0.0-54" author="wiki" failOnError="false">
     <addUniqueConstraint columnNames="OWNER, TYPE" tableName="WIKI_WIKIS"

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -404,6 +404,61 @@ export default {
       published: false
     };
   },
+  watch: {
+    note: {
+      deep: true,
+      handler() {
+        if (!this.note.draftPage) {
+          this.getNoteVersionByNoteId(this.note.id);
+        }
+        if ( this.note && this.note.breadcrumb && this.note.breadcrumb.length ) {
+          this.note.breadcrumb[0].title = this.getHomeTitle(this.note.breadcrumb[0].title);
+          this.currentNoteBreadcrumb = this.note.breadcrumb;
+        }
+        this.noteTitle = !this.note.parentPageId && this.note.title==='Home' ? `${this.$t('notes.label.noteHome')}` : this.note.title;
+        this.noteContent = this.note.content;
+        this.noteSummary = this.note?.properties?.summary;
+        if (this.hasEmptyContent || this.isHomeNoteDefaultContent) {
+          this.retrieveNoteTreeById();
+        }
+      }
+    },
+    actualVersion() {
+      if (!this.isDraft && this.actualVersion) {
+        this.noteContent = this.actualVersion.content;
+        this.displayLastVersion = false;
+      }
+    },
+    exportStatus(){
+      if (this.exportStatus.status==='ZIP_CREATED'){
+        this.stopGetStatus();
+        this.getExportedZip();
+        this.exportStatus={};
+      }
+      if (this.exportStatus.status===null){
+        this.stopGetStatus();
+        this.exportStatus={};
+      }
+    },
+    initialized() {
+      if (this.initialized) {
+        Vue.prototype.$utils.includeExtensions('NotesExtension');
+        const urlHash = window.location.hash;
+        if (urlHash) {
+          const elementId = urlHash.substring(1);
+          const targetElement = document.getElementById(elementId);
+          if (targetElement) {
+            targetElement.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
+      }
+    },
+    noteTitle() {
+      const companyName = eXo.env.portal.companyName;
+      const spaceDisplayName = eXo.env.portal.spaceDisplayName;
+      window.document.title = `Note: ${this.noteTitle} - ${spaceDisplayName} - ${companyName}`;
+    }
+  },
   computed: {
     extensionParams() {
       return {


### PR DESCRIPTION
Prior to this change, for some reason, on some instances some wiki entrees are duplicated on OWNER,TYPE attributes for WIKI_WIKIS table despite of unique constraint on those columns added by changeSet of id="1.0.0-54". This makes this kind of exception: 
`ChangeSet db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-54::wiki encountered an exception. [liquibase.changelog.ChangeSet] liquibase.exception.DatabaseException: Duplicate entry 'nessrineberrama-user' for key 'WIKI_WIKIS.UK_WIKI_WIKIS_OWNER_TYPE_01' [Failed SQL: (1062) ALTER TABLE community.WIKI_WIKIS ADD CONSTRAINT UK_WIKI_WIKIS_OWNER_TYPE_01 UNIQUE (OWNER, TYPE)].`
After this commit, we added a changeset of id="1.0.0-53-clean-duplicates" which will be executed before changeset 1.0.0-54 in order to clean these duplicated entries and let the next changesets to be executed normally.

Resolves meeds-io/meeds#3924