### PR TITLE
fix: Cleanup duplicated wiki entries - MEED-10114 - Meeds-io/meeds#3924

### DIFF
--- a/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
+++ b/notes-service/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
@@ -455,6 +455,50 @@
       columnDataType="TIMESTAMP"
       defaultNullValue="${now}" />
   </changeSet>
+  
+  <changeSet id="1.0.0-53-clean-pages" author="wiki">
+    <sql>
+		DELETE FROM WIKI_PAGES
+		WHERE WIKI_ID IN (
+		  SELECT w1.WIKI_ID
+		  FROM WIKI_WIKIS w1
+		  JOIN WIKI_WIKIS w2
+			ON w1.OWNER = w2.OWNER
+		   AND w1.TYPE = w2.TYPE
+		   AND w1.WIKI_ID > w2.WIKI_ID
+		)
+    </sql>
+  </changeSet>
+  
+  <changeSet id="1.0.0-53-clean-templates" author="wiki">
+    <sql>
+		DELETE FROM WIKI_TEMPLATES
+		WHERE WIKI_ID IN (
+		  SELECT w1.WIKI_ID
+		  FROM WIKI_WIKIS w1
+		  JOIN WIKI_WIKIS w2
+			ON w1.OWNER = w2.OWNER
+		   AND w1.TYPE = w2.TYPE
+		   AND w1.WIKI_ID > w2.WIKI_ID
+		)
+    </sql>
+  </changeSet>
+  
+  <changeSet id="1.0.0-53-clean-wikis" author="wiki">
+    <sql>
+		DELETE FROM WIKI_WIKIS
+        WHERE WIKI_ID IN (
+          SELECT WIKI_ID FROM (
+            SELECT w1.WIKI_ID
+            FROM WIKI_WIKIS w1
+            JOIN WIKI_WIKIS w2
+            ON w1.OWNER = w2.OWNER
+            AND w1.TYPE = w2.TYPE
+            AND w1.WIKI_ID > w2.WIKI_ID
+          ) dup
+        );
+    </sql>
+  </changeSet>
 
   <changeSet id="1.0.0-54" author="wiki" failOnError="false">
     <addUniqueConstraint columnNames="OWNER, TYPE" tableName="WIKI_WIKIS"


### PR DESCRIPTION

Prior to this change, for some reason, on some instances some wiki entrees are duplicated on OWNER,TYPE attributes for WIKI_WIKIS table despite of unique constraint on those columns added by changeSet of id="1.0.0-54". This makes this kind of exception:
`ChangeSet db/changelog/wiki.db.changelog-1.0.0.xml::1.0.0-54::wiki encountered an exception. [liquibase.changelog.ChangeSet] liquibase.exception.DatabaseException: Duplicate entry 'nessrineberrama-user' for key 'WIKI_WIKIS.UK_WIKI_WIKIS_OWNER_TYPE_01' [Failed SQL: (1062) ALTER TABLE community.WIKI_WIKIS ADD CONSTRAINT UK_WIKI_WIKIS_OWNER_TYPE_01 UNIQUE (OWNER, TYPE)].` After this commit, we added a changeset of
id="1.0.0-53-clean-duplicates" which will be executed before changeset 1.0.0-54 in order to clean these duplicated entries and let the next changesets to be executed normally.

Resolves meeds-io/meeds#3924