### PR TITLE
fix: Restore the title, summary and illustration note when reverting to a previous version- MEED-10085 - meeds-io/meeds#3943 

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/model/PageHistory.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/model/PageHistory.java
@@ -18,26 +18,11 @@
  */
 package org.exoplatform.wiki.model;
 
-import java.util.Date;
-
 import lombok.Data;
 
 @Data
-public class PageHistory {
-
-  private Long   id;
+public class PageHistory extends PageVersion{
 
   private Long   versionNumber;
 
-  private String author;
-
-  private String authorFullName;
-
-  private Date   createdDate;
-
-  private Date   updatedDate;
-
-  private String content;
-
-  private String lang;
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NoteService.java
@@ -908,9 +908,10 @@ public interface NoteService {
    * @param isDraft is target not a draft
    * @param thumbnailSize featured image thumbnail size
    * @param userIdentityId user identity id
+   * @param versionNumber note version number
    * @return {@link NoteFeaturedImage}
    */
-  NoteFeaturedImage getNoteFeaturedImageInfo(Long noteId, String lang, boolean isDraft, String thumbnailSize, long userIdentityId) throws Exception;
+  NoteFeaturedImage getNoteFeaturedImageInfo(Long noteId, String lang, boolean isDraft, String thumbnailSize, long userIdentityId, Long versionNumber) throws Exception;
 
   /**
    * Save note metadata properties

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -288,6 +288,14 @@ public class NoteServiceImpl implements NoteService {
         eventData.put(PAGE_VERSION_ID_PROP_NAME, pageVersion.getId());
         Utils.broadcast(listenerService, "note.page.version.created", this, eventData);
       }
+      pageVersion.setId(createdPage.getId() + "-" + pageVersion.getName());
+      copyNotePageProperties(createdPage,
+              pageVersion,
+              note.getLang(),
+              null,
+              NOTE_METADATA_PAGE_OBJECT_TYPE,
+              NOTE_METADATA_VERSION_PAGE_OBJECT_TYPE,
+              userIdentity.getUserId());
       return createdPage;
     } else {
       throw new EntityNotFoundException("Parent note not found");
@@ -1617,11 +1625,13 @@ public class NoteServiceImpl implements NoteService {
                                                     String lang,
                                                     boolean isDraft,
                                                     String thumbnailSize,
-                                                    long userIdentityId) throws Exception {
+                                                    long userIdentityId,
+                                                    Long versionNumber) throws Exception {
     if (noteId == null) {
       throw new IllegalArgumentException("note id is mandatory");
     }
     org.exoplatform.social.core.identity.model.Identity identity = identityManager.getIdentity(userIdentityId);
+    String metadataType = isDraft ? NOTE_METADATA_DRAFT_PAGE_OBJECT_TYPE : NOTE_METADATA_PAGE_OBJECT_TYPE;
     Page note;
     if (isDraft) {
       note = getDraftNoteById(String.valueOf(noteId), identity.getRemoteId());
@@ -1631,11 +1641,13 @@ public class NoteServiceImpl implements NoteService {
     if (note == null) {
       throw new ObjectNotFoundException("Note with id: " + noteId + " and lang: " + lang + " not found");
     }
-
+    if (versionNumber != null) {
+      note.setId(note.getId() + "-" + String.valueOf(versionNumber));
+      metadataType = NOTE_METADATA_VERSION_PAGE_OBJECT_TYPE;
+    }
     MetadataItem metadataItem = getNoteMetadataItem(note,
                                                     lang,
-                                                    isDraft ? NOTE_METADATA_DRAFT_PAGE_OBJECT_TYPE :
-                                                            NOTE_METADATA_PAGE_OBJECT_TYPE);
+                                                    metadataType);
     if (metadataItem != null && !MapUtils.isEmpty(metadataItem.getProperties())) {
       String featuredImageIdProp = metadataItem.getProperties().get(FEATURED_IMAGE_ID);
       String featuredImageAltText = metadataItem.getProperties().get(FEATURED_IMAGE_ALT_TEXT);

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1410,7 +1410,8 @@ public class NotesRestService implements ResourceContainer {
                                        @Parameter(description = "target version language", required = true) @QueryParam("isDraft") boolean isDraft,
                                        @Parameter(description = "target version language", required = true) @QueryParam("lang") String lang,
                                        @Parameter(description = "Optional size parameter", required = true) @QueryParam("size") String size,
-                                       @Parameter(description = "Optional last modified parameter") @QueryParam("v") long lastModified) {
+                                       @Parameter(description = "Optional last modified parameter") @QueryParam("v") long lastModified,
+                                       @Parameter(description = "Optional version number") @QueryParam("versionNumber") Long versionNumber) {
 
     if (noteId == null) {
       return Response.status(Response.Status.BAD_REQUEST).entity("note id is mandatory").build();
@@ -1420,7 +1421,8 @@ public class NotesRestService implements ResourceContainer {
                                                                                  lang,
                                                                                  isDraft,
                                                                                  size,
-                                                                                 RestUtils.getCurrentUserIdentityId());
+                                                                                 RestUtils.getCurrentUserIdentityId(),
+                                                                                 versionNumber);
       if (noteFeaturedImage == null) {
         return Response.status(HTTPStatus.NOT_FOUND).build();
       }

--- a/notes-service/src/main/java/org/exoplatform/wiki/storage/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/storage/EntityConverter.java
@@ -147,23 +147,28 @@ public class EntityConverter {
       page.setActivityId(pageEntity.getActivityId());
       page.setDeleted(pageEntity.isDeleted());
       page.setUrl(Utils.getPageUrl(page));
-      buildNotePageMetadata(page, page.isDraftPage());
+      buildNotePageMetadata(page, page.isDraftPage(), String.valueOf(pageEntity.getId()));
     }
     return page;
   }
   
-  public static void buildNotePageMetadata(Page note, boolean isDraft) {
+  public static void buildNotePageMetadata(Page note, boolean isDraft, String pageId) {
     if (note == null) {
       return;
     }
     Space space = getSpaceService().getSpaceByGroupId(note.getWikiOwner());
     String spaceId = space != null ? space.getId() : "0";
     String noteId = note.getId();
+    String metaDataType = isDraft ? "noteDraftPage" : "notePage";
+    if (note instanceof PageHistory) {
+      noteId = pageId + "-" + ((PageHistory) note).getVersionNumber();
+      metaDataType = "noteVersionPage";
+    }
     if (note.getLang() != null) {
       noteId = noteId + "-" + note.getLang();
     }
     Map<String, String> originalNoteSharedProperties = getOriginalNoteSharedProperties(note, spaceId);
-    NoteMetadataObject noteMetadataObject = new NoteMetadataObject(isDraft ? "noteDraftPage" : "notePage",
+    NoteMetadataObject noteMetadataObject = new NoteMetadataObject(metaDataType,
                                                                    noteId,
                                                                    note.getParentPageId(),
                                                                    Long.parseLong(spaceId));
@@ -252,7 +257,7 @@ public class EntityConverter {
           draftPage.setWikiType(wiki.getType());
         }
       }
-      buildNotePageMetadata(draftPage, true);
+      buildNotePageMetadata(draftPage, true, String.valueOf(draftPageEntity.getId()));
     }
     return draftPage;
   }
@@ -282,7 +287,7 @@ public class EntityConverter {
         draftPageEntity.setParentPage(pageDAO.find(Long.valueOf(parentPageId)));
       }
       draftPageEntity.setTargetRevision(draftPage.getTargetPageRevision());
-      buildNotePageMetadata(draftPage, true);
+      buildNotePageMetadata(draftPage, true, draftPage.getId());
     }
     return draftPageEntity;
   }
@@ -303,7 +308,7 @@ public class EntityConverter {
       pageVersion.setParent(convertPageEntityToPage(pageVersionEntity.getPage()));
       pageVersion.setLang(pageVersionEntity.getLang());
       pageVersion.setWikiOwner(pageVersionEntity.getPage().getWiki().getOwner());
-      buildNotePageMetadata(pageVersion, pageVersion.isDraftPage());
+      buildNotePageMetadata(pageVersion, pageVersion.isDraftPage(), String.valueOf(pageVersionEntity.getPage().getId()));
     }
     return pageVersion;
   }
@@ -312,13 +317,15 @@ public class EntityConverter {
     PageHistory pageHistory = null;
     if (pageVersionEntity != null) {
       pageHistory = new PageHistory();
-      pageHistory.setId(pageVersionEntity.getId());
+      pageHistory.setId(String.valueOf(pageVersionEntity.getId()));
       pageHistory.setVersionNumber(pageVersionEntity.getVersionNumber());
       pageHistory.setAuthor(pageVersionEntity.getAuthor());
       pageHistory.setContent(pageVersionEntity.getContent());
       pageHistory.setCreatedDate(pageVersionEntity.getCreatedDate());
       pageHistory.setUpdatedDate(pageVersionEntity.getUpdatedDate());
       pageHistory.setLang(pageVersionEntity.getLang());
+      pageHistory.setTitle(pageVersionEntity.getTitle());
+      buildNotePageMetadata(pageHistory, false, String.valueOf(pageVersionEntity.getPage().getId()));
       if (StringUtils.isNotBlank(pageHistory.getAuthor())) {
         Identity identity = ExoContainerContext.getService(IdentityManager.class)
             .getOrCreateUserIdentity(pageHistory.getAuthor());
@@ -399,4 +406,5 @@ public class EntityConverter {
     }
     return metadataService;
   }
+
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/storage/NoteDataStorage.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/storage/NoteDataStorage.java
@@ -922,7 +922,7 @@ public class NoteDataStorage {
     if (pageVersion != null) {
       Page page = pageVersion.getParent();
       page.setLang(lang);
-      EntityConverter.buildNotePageMetadata(page, false);
+      EntityConverter.buildNotePageMetadata(page, false, page.getId());
       pageVersion.setProperties(page.getProperties());
       return pageVersion;
     }

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
@@ -667,7 +667,8 @@ public class TestNoteService extends BaseTest {
                                                                            "fr",
                                                                            false,
                                                                            null,
-                                                                           Long.parseLong(identity.getId()));
+                                                                           Long.parseLong(identity.getId()),
+                                                                           null);
     assertNotNull(featuredImage);
     noteService.deleteVersionsByNoteIdAndLang(Long.valueOf(note1.getId()), "en", true);
     Page note = noteService.getNoteByIdAndLang(Long.valueOf(note1.getId()), root, "", "en");
@@ -850,12 +851,14 @@ public class TestNoteService extends BaseTest {
                                                                                    null,
                                                                                    false,
                                                                                    null,
-                                                                                   getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                                                   getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                                                   null);
     NoteFeaturedImage noteFeaturedImageInfoFr = noteService.getNoteFeaturedImageInfo(Long.parseLong(note.getId()),
                                                                                      "fr",
                                                                                      false,
                                                                                      null,
-                                                                                     getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                                                     getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                                                     null);
 
     assertNotNull(noteFeaturedImageInfo);
     assertNotNull(noteFeaturedImageInfoFr);
@@ -871,12 +874,14 @@ public class TestNoteService extends BaseTest {
                                                     null,
                                                     false,
                                                     null,
-                                                    getIdentityId(ROOT_IDENTITY.getUserId())));
+                                                    getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                    null));
     assertNull(noteService.getNoteFeaturedImageInfo(Long.parseLong(note.getId()),
                                                     "fr",
                                                     false,
                                                     null,
-                                                    getIdentityId(ROOT_IDENTITY.getUserId())));
+                                                    getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                    null));
   }
 
   public void testGetNoteFeaturedImageInfo() throws Exception {
@@ -892,12 +897,14 @@ public class TestNoteService extends BaseTest {
                                                                            null,
                                                                            false,
                                                                            "150x150",
-                                                                           getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                                           getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                                           null);
     NoteFeaturedImage versionLanguageFeaturedImage = noteService.getNoteFeaturedImageInfo(Long.parseLong(note.getId()),
                                                                                           "ar",
                                                                                           false,
                                                                                           "150x150",
-                                                                                          getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                                                          getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                                                          null);
 
     assertNotNull(featuredImage);
     assertTrue(featuredImage.getLastUpdated() > 0L);
@@ -1011,7 +1018,8 @@ public class TestNoteService extends BaseTest {
                                                                          null,
                                                                          true,
                                                                          null,
-                                                                         getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                                         getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                                         null);
     assertNotNull(featuredImage);
     noteService.removeDraftById(draftPage.getId());
     assertNull(fileService.getFile(featuredImage.getId()));
@@ -1041,7 +1049,8 @@ public class TestNoteService extends BaseTest {
                                                          null,
                                                          true,
                                                          null,
-                                                         getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                         getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                         null);
     assertNotNull(featuredImage);
     noteService.removeDraftById(draftPage.getId());
     assertNotNull(fileService.getFile(featuredImage.getId()));
@@ -1056,7 +1065,8 @@ public class TestNoteService extends BaseTest {
                                                          null,
                                                          true,
                                                          null,
-                                                         getIdentityId(ROOT_IDENTITY.getUserId()));
+                                                         getIdentityId(ROOT_IDENTITY.getUserId()),
+                                                         null);
     assertNotNull(featuredImage);
     noteService.removeDraftById(draftPage.getId());
     assertNull(fileService.getFile(featuredImage.getId()));

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -449,7 +449,7 @@ public class NotesRestServiceTest extends AbstractKernelTest {
   @Test
   public void getFeaturedImageIllustration() throws Exception {
     Request request = mock(Request.class);
-    Response response = notesRestService.getFeaturedImageIllustration(request, null, false, null, null,0L);
+    Response response = notesRestService.getFeaturedImageIllustration(request, null, false, null, null,0L, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     REST_UTILS.when(RestUtils::getCurrentUserIdentityId).thenReturn(1L);
 
@@ -457,17 +457,17 @@ public class NotesRestServiceTest extends AbstractKernelTest {
     noteFeaturedImage.setId(123L);
     noteFeaturedImage.setLastUpdated(new Date().getTime());
     noteFeaturedImage.setMimeType("image/png");
-    when(noteService.getNoteFeaturedImageInfo(1L, null, false, "150x150", 1L)).thenReturn(noteFeaturedImage);
-    response = notesRestService.getFeaturedImageIllustration(request, 1L, false, null, "150x150", 12359547L);
+    when(noteService.getNoteFeaturedImageInfo(1L, null, false, "150x150", 1L, null)).thenReturn(noteFeaturedImage);
+    response = notesRestService.getFeaturedImageIllustration(request, 1L, false, null, "150x150", 12359547L, null);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    when(noteService.getNoteFeaturedImageInfo(1L, null, false, "150x150", 1L)).thenThrow(new ObjectNotFoundException("note not found"));
-    response = notesRestService.getFeaturedImageIllustration(request, 1L, false, null, "150x150", 12359547L);
+    when(noteService.getNoteFeaturedImageInfo(1L, null, false, "150x150", 1L, null)).thenThrow(new ObjectNotFoundException("note not found"));
+    response = notesRestService.getFeaturedImageIllustration(request, 1L, false, null, "150x150", 12359547L, null);
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
 
     reset(noteService);
-    when(noteService.getNoteFeaturedImageInfo(1L, null, false, "150x150", 1L)).thenThrow(new RuntimeException());
-    response = notesRestService.getFeaturedImageIllustration(request, 1L, false, null, "150x150", 12359547L);
+    when(noteService.getNoteFeaturedImageInfo(1L, null, false, "150x150", 1L, null)).thenThrow(new RuntimeException());
+    response = notesRestService.getFeaturedImageIllustration(request, 1L, false, null, "150x150", 12359547L, null);
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 }

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -479,7 +479,7 @@ export default {
       return this.note?.properties?.featuredImage?.altText;
     },
     featuredImageLink() {
-      return `${this.illustrationBaseUrl}${this.note?.id}?v=${this.noteFeatureImageUpdatedDate}&isDraft=${this.isDraft}${this.langParam}&size=0x400`;
+      return `${this.illustrationBaseUrl}${this.note?.id}?v=${this.noteFeatureImageUpdatedDate}&isDraft=${this.isDraft}${this.langParam}&versionNumber=${this.actualVersion?.versionNumber}&size=0x400`;
     },
     notesContentProcessor() {
       return {
@@ -1049,16 +1049,24 @@ export default {
       this.actualVersion = version;
       this.actualVersion.current = true;
       this.note.content = version.content;
+      this.note.title = version.title;
+      this.noteSummary = version.properties.summary;
+      this.note.properties = version.properties;
+      this.noteTitle = version.title;
     },
     restoreVersion(version) {
       const note = {
         id: this.note.id,
-        title: this.note.title,
+        title: version.title,
         content: version.content,
         updatedDate: version.updatedDate,
-        owner: version.author
+        owner: version.author,
+        properties: version.properties
       };
       this.note.content = version.content;
+      this.note.title = version.title;
+      this.noteSummary = version.properties.summary;
+      this.note.properties = version.properties;
       this.$notesService.restoreNoteVersion(note,version.versionNumber)
         .catch(e => {
           console.error('Error when restore note version', e);


### PR DESCRIPTION
Before this change, when restoring a note, the title, summary and featured image were not restored because these properties of each version of the note are saved, but they are not restored when the version details are retrieved. In addition, the properties of the first version of the note were not saved.
This commit adapts the code; change the pageHistory model and add buildNotePageMetadata method when retrieving note versions to obtain the properties of each one with the appropriate version number.

Resolves: Meeds-io/meeds#3943
