### PR TITLE
fix: Images added in SNV Quick edit are not saved - MEED-10139 - Meeds-io/meeds#3991 (#1600)

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/service/NotePageViewService.java
+++ b/notes-service/src/main/java/io/meeds/notes/service/NotePageViewService.java
@@ -122,7 +122,8 @@ public class NotePageViewService {
       return null;
     }
     String pageContent = pages.get(DEFAULT_CONTENT_LANG);
-    Page page = saveNotePage(name, pageContent, null, userACL.getSuperUser());
+    Identity identity = userACL.getUserIdentity(userACL.getSuperUser());
+    Page page = persistNotePage(name, pageContent, null, identity);
     String pageId = page.getId(); // NOSONAR
     String pageContentReplacement = clonePageAttachments(pageId, pageContent);
     if (!StringUtils.equals(pageContentReplacement, pageContent)) {
@@ -192,13 +193,13 @@ public class NotePageViewService {
     } else if (!cmsService.hasEditPermission(currentUserAclIdentity, CMS_CONTENT_TYPE, name)) {
       throw new IllegalAccessException("Note page isn't editable");
     }
-    return saveNotePage(name, content, lang, currentUserAclIdentity.getUserId());
+    return persistNotePage(name, content, lang, currentUserAclIdentity);
   }
 
-  private Page saveNotePage(String name,
+  private Page persistNotePage(String name,
                             String content,
                             String lang,
-                            String username) {
+                            Identity userIdentity) {
     CMSSetting setting = cmsService.getSetting(CMS_CONTENT_TYPE, name);
     String pageReference = setting.getPageReference();
     PageKey pageKey = PageKey.create(pageReference);
@@ -221,18 +222,18 @@ public class NotePageViewService {
           page.setLang(null);
           page.setContent(content);
           page.setUpdatedDate(new Date());
-          page = noteService.updateNote(page, PageUpdateType.EDIT_PAGE_CONTENT);
+          page = noteService.updateNote(page, PageUpdateType.EDIT_PAGE_CONTENT, userIdentity);
         } else {
           page.setUpdatedDate(new Date());
           page = noteService.updateNote(page, PageUpdateType.EDIT_PAGE_CONTENT);
           page.setContent(content);
           page.setLang(pageWithLang.getLang());
         }
-        noteService.createVersionOfNote(page, username);
+        noteService.createVersionOfNote(page, userIdentity.getUserId());
         noteService.removeDraftOfNote(page);
       }
       return getNotePage(pageKey, name, lang);
-    } catch (WikiException e) {
+    } catch (Exception e) {
       throw new IllegalStateException(String.format("Error retrieving note with name %s referenced in page %s",
                                                     name,
                                                     pageKey),

--- a/notes-service/src/test/java/io/meeds/notes/rest/NotePageViewRestTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/rest/NotePageViewRestTest.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.exoplatform.services.organization.OrganizationService;
 import org.mockito.MockedStatic;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
@@ -73,12 +74,15 @@ public class NotePageViewRestTest extends AbstractResourceTest { // NOSONAR
 
   private IdentityRegistry               identityRegistry;
 
+  private OrganizationService            organizationService;
+
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     this.cmsService = getContainer().getComponentInstanceOfType(CMSServiceImpl.class);
     this.layoutService = getContainer().getComponentInstanceOfType(LayoutService.class);
     this.identityRegistry = getContainer().getComponentInstanceOfType(IdentityRegistry.class);
+    this.organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
 
     NotePageViewService notePageViewService = getContainer().getComponentInstanceOfType(NotePageViewService.class);
     registry(new NotePageViewRest(notePageViewService));
@@ -164,6 +168,7 @@ public class NotePageViewRestTest extends AbstractResourceTest { // NOSONAR
     response = getNotePageWithETag(pageNoteName, null, eTagValue);
     assertEquals(304, response.getStatus());
 
+    createUser(USERNAME);
     registerAdministratorUser(USERNAME);
     response = saveNotePage(pageNoteName, pageContent, null);
     assertEquals(204, response.getStatus());
@@ -261,6 +266,15 @@ public class NotePageViewRestTest extends AbstractResourceTest { // NOSONAR
     REST_UTILS.when(RestUtils::getCurrentUser).thenReturn(USERNAME);
     REST_UTILS.when(RestUtils::getCurrentUserAclIdentity).thenReturn(identity);
     return identity;
+  }
+
+  private void createUser(String username) {
+    try {
+      organizationService.getUserHandler().createUser(
+              organizationService.getUserHandler().createUserInstance(username), true);
+    } catch (Exception e) {
+      //Nothing
+    }
   }
 
   private org.exoplatform.services.security.Identity registerInternalUser(String username) {

--- a/notes-service/src/test/java/io/meeds/notes/service/NotePageViewServiceTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/service/NotePageViewServiceTest.java
@@ -33,6 +33,7 @@ import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.page.PageState;
 import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.wiki.WikiException;
@@ -72,6 +73,8 @@ public class NotePageViewServiceTest extends BaseTest { // NOSONAR
 
   private IdentityRegistry      identityRegistry;
 
+  private OrganizationService  organizationService;
+
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -79,6 +82,7 @@ public class NotePageViewServiceTest extends BaseTest { // NOSONAR
     this.cmsService = getContainer().getComponentInstanceOfType(CMSServiceImpl.class);
     this.layoutService = getContainer().getComponentInstanceOfType(LayoutService.class);
     this.identityRegistry = getContainer().getComponentInstanceOfType(IdentityRegistry.class);
+    this.organizationService = getContainer().getComponentInstanceOfType(OrganizationService.class);
     this.noteService = getContainer().getComponentInstanceOfType(NoteService.class);
   }
 
@@ -122,6 +126,7 @@ public class NotePageViewServiceTest extends BaseTest { // NOSONAR
                  () -> notePageViewService.saveNotePage(pageNoteName, pageContentEn, null, registerInternalUser(USERNAME)));
     notePageViewService.saveNotePage(pageNoteName, pageContentFr, null, registerAdministratorUser(USERNAME));
     // Test save a language not saved, which has to change the default lang
+    createUser(USERNAME);
     notePageViewService.saveNotePage(pageNoteName, pageContentEn, "fr", registerAdministratorUser(USERNAME));
 
     assertThrows(IllegalAccessException.class, () -> notePageViewService.getNotePage(pageNoteName, null, null));
@@ -169,6 +174,7 @@ public class NotePageViewServiceTest extends BaseTest { // NOSONAR
     assertNotNull(notePage);
     assertEquals(pageContent, notePage.getContent());
 
+    createUser(USERNAME);
     notePageViewService.saveNotePage(pageNoteName, pageContentModified, null, registerAdministratorUser(USERNAME));
 
     notePage = notePageViewService.getNotePage(pageNoteName, "fr", registerInternalUser(USERNAME));
@@ -235,6 +241,15 @@ public class NotePageViewServiceTest extends BaseTest { // NOSONAR
                                                                                                        Arrays.asList(new MembershipEntry("/platform/administrators")));
     identityRegistry.register(identity);
     return identity;
+  }
+
+  private void createUser(String username) {
+    try {
+      organizationService.getUserHandler().createUser(
+              organizationService.getUserHandler().createUserInstance(username), true);
+    } catch (Exception e) {
+      //Nothing
+    }
   }
 
   private org.exoplatform.services.security.Identity registerInternalUser(String username) {


### PR DESCRIPTION
Prior to this change, images added in SNV quick edit mode were not saved due to missing user identity.
This PR fixes the issue by passing the current `UserIdentity` to `saveNotePage` in `PageViewService`. By providing the correct user context, `NoteService.updateNoteContentImages` can now correctly parse and save pasted images, ensuring they appear properly after saving in quick edit mode.

(cherry picked from commit ea4b4184e9cbb57dd746109a57ab3f7d97d6c662)