### PR TITLE
fix: Fix note display when increasing the treeview size - MEED-10235 - Meeds-io/MIPs#235

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <v-container fluid class="pa-0">
-    <v-row no-gutters class="pa-5">
+    <v-row no-gutters class="pa-5 flex-nowrap">
       <v-sheet
         v-if="treeViewExpended && !$root.isMobile"
         :width="sidebarWidth"


### PR DESCRIPTION
This change will fix the display of note page when increasing the treeview size