### PR TITLE
fix: Breadcrumb displayed title not updated when restore a version - MEED-10215 - Meeds-io/meeds#4029

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -2079,7 +2079,7 @@ public class NoteServiceImpl implements NoteService {
 
   private String getNoteTitleWithTraduction(Page note, Identity userIdentity, String source, String lang) throws WikiException,
                                                                                                           IllegalAccessException {
-    if (userIdentity == null || StringUtils.isEmpty(lang)) {
+    if (userIdentity == null) {
       return note.getTitle();
     }
     Page page = getNoteByIdAndLang(Long.valueOf(note.getId()), userIdentity, source, lang);

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -319,7 +319,7 @@ public class NotesRestService implements ResourceContainer {
       note.setBreadcrumb(noteService.getBreadCrumb(note.getWikiType(),
                                                    note.getWikiOwner(),
                                                    note.getName(),
-                                                   request.getLocale().getLanguage(),
+                                                   lang,
                                                    identity,
                                                    false));
       return Response.ok(note).build();

--- a/notes-service/src/main/java/org/exoplatform/wiki/storage/EntityConverter.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/storage/EntityConverter.java
@@ -325,6 +325,7 @@ public class EntityConverter {
       pageHistory.setUpdatedDate(pageVersionEntity.getUpdatedDate());
       pageHistory.setLang(pageVersionEntity.getLang());
       pageHistory.setTitle(pageVersionEntity.getTitle());
+      pageHistory.setName(pageVersionEntity.getName());
       buildNotePageMetadata(pageHistory, false, String.valueOf(pageVersionEntity.getPage().getId()));
       if (StringUtils.isNotBlank(pageHistory.getAuthor())) {
         Identity identity = ExoContainerContext.getService(IdentityManager.class)

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -580,8 +580,13 @@ export default {
     canScheduleNotePublication() {
       return this.note?.canManage || this.canSchedule;
     },
+    hasTranslations() {
+      return !!this.translations?.length;
+    },
     targetLang() {
-      return this.selectedTranslation?.value || this.lang;
+      return this.hasTranslations
+        ? (this.selectedTranslation?.value || this.lang)
+        : null;
     },
     parentPageId() {
       return this.note?.parentPageId;
@@ -1069,6 +1074,7 @@ export default {
     restoreVersion(version) {
       const note = {
         id: this.note.id,
+        name: version.name,
         title: version.title,
         content: version.content,
         updatedDate: version.updatedDate,


### PR DESCRIPTION
Prior to this change, when restoring a version, the breadcrumb displayed the original note title instead of the selected version’s title.

This happened because the `getBreadcrumb` endpoint did not take the lang query parameter into account. Instead, it relied on the request’s locale language. As a result, when the requested locale did not match the targeted version language, the endpoint fell back to the original note title.

This PR updates the title resolution logic to use the provided target language query parameter, ensuring that the correct version title is displayed in the breadcrumb.