### PR TITLE
fix: Toc displayed title not updated when restore a version - MEED-10246 - Meeds-io/meeds#4029

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -2083,10 +2083,11 @@ public class NoteServiceImpl implements NoteService {
       return note.getTitle();
     }
     Page page = getNoteByIdAndLang(Long.valueOf(note.getId()), userIdentity, source, lang);
-    if (page != null) {
+    if (page != null && page.getLang() != null) {
       return page.getTitle();
     }
-    return note.getTitle();
+    Page publishedVersion = getPublishedVersionByPageIdAndLang(Long.valueOf(note.getId()), null);
+    return Objects.requireNonNullElse(publishedVersion, note).getTitle();
   }
 
   private String getDraftNameSuffix(long clientTime) {

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -319,7 +319,7 @@ public class NotesRestService implements ResourceContainer {
       note.setBreadcrumb(noteService.getBreadCrumb(note.getWikiType(),
                                                    note.getWikiOwner(),
                                                    note.getName(),
-                                                   lang,
+                                                   request.getLocale().getLanguage(),
                                                    identity,
                                                    false));
       return Response.ok(note).build();

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
@@ -294,8 +294,13 @@ public class TreeUtils {
     } else {
       if (!nodeData.isDraftPage()) {
         Page page = noteService.getNoteByIdAndLang(Long.valueOf(nodeData.getNoteId()), identity, "", locale.getLanguage());
-        if (page != null) {
+        if (page != null && page.getLang() != null) {
           nodeData.setName(page.getTitle());
+          return;
+        }
+        Page publishedVersion = noteService.getPublishedVersionByPageIdAndLang(Long.valueOf(nodeData.getNoteId()), null);
+        if (publishedVersion != null) {
+          nodeData.setName(publishedVersion.getTitle());
         }
       }
     }

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -580,13 +580,8 @@ export default {
     canScheduleNotePublication() {
       return this.note?.canManage || this.canSchedule;
     },
-    hasTranslations() {
-      return !!this.translations?.length;
-    },
     targetLang() {
-      return this.hasTranslations
-        ? (this.selectedTranslation?.value || this.lang)
-        : null;
+      return this.selectedTranslation?.value || this.lang;
     },
     parentPageId() {
       return this.note?.parentPageId;


### PR DESCRIPTION
Prior to this change, when restoring a version, the table of content displays the original note title instead of the selected version’s title.
This happened because the Resolving titles of Toc json tree doesn't take into consideration the non exiting or target default request lang version
This PR updates the title resolution to check the existence of the target version lang otherwise returns last published version title, ensuring that the correct version title is