### PR TITLE
fix: Fix page access from the Navigation tool in a note page - MEED-10309 - Meeds-io/meeds#4127

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
@@ -436,6 +436,13 @@ export default {
       sortField: 'lastUpdated',
     };
   },
+  provide() {
+    return {
+      openNoteChild: this.openNoteChild,
+      fetchChildren: this.fetchChildren,
+      getNoteLanguages: this.getNoteLanguages,
+    };
+  },
   computed: {
     extensionParams() {
       return {


### PR DESCRIPTION
This change will resolve intermittent method access errors in note tree view by adding provide() in parent component to expose used methods