### PR TITLE
fix: print to pdf freezes the 3 dots menu - MEED-10290 - Meeds-io/meeds#4074 

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
@@ -67,13 +67,13 @@
               </div>
             </v-col>
             <v-col
+              id="note-actions-menu"
               xl="2"
               lg="2"
               md="3"
               sm="4"
               cols="6">
               <div
-                id="note-actions-menu"
                 v-if="loadData && !hideElementsForSavingPDF"
                 class="notes-header-icons text-right d-flex justify-end">
                 <div

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
@@ -1108,7 +1108,7 @@ export default {
             console.error('Error when exporting note: ', e);
           });
         });
-      }, 200);
+      }, 400);
     },
     displayMessage(message) {
       this.$root.$emit('alert-message', message?.message, message?.type || 'success');


### PR DESCRIPTION
Before this change, when go to notesA and open 3 dots menu and click on print to pdf then open again the same menu, the menu becomes unusable. after this change, the menu should display the actions list.
Resolves https://github.com/Meeds-io/meeds/issues/4074