### PR TITLE
fix: Remove Treeview label on the treeview header - MEED-10291 - Mees-io/meeds#4065 (#1637)

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
@@ -39,9 +39,6 @@
       @filter-button-click="$root.$emit('notes-filter-open', filter)"
       @filter-expand="filterExpand = $event"
       @loading="$emit('loading', $event)">
-      <template #left>
-        <span class="text-header">{{ $t('notes.label.tree') }}</span>
-      </template>
     </application-toolbar>
     <v-tooltip v-if="!filterExpand" bottom>
       <template #activator="{ on, attrs }">


### PR DESCRIPTION
Before this change, when the translation of the Treeview label is too long it's split in 2. To fix this issue, remove the template tag where the treeview text exists. After this change, the Treeview label on the treeview header is removed.
Resolves https://github.com/Meeds-io/meeds/issues/4065