### PR TITLE
fix: print to pdf freezes the 3 dots menu - MEED-10290 - Meeds-io/meeds#4074

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -47,6 +47,7 @@
               </div>
             </v-col>
             <v-col
+              id="note-actions-menu"
               xl="2"
               lg="2"
               md="3"
@@ -1029,7 +1030,7 @@ export default {
             console.error('Error when exporting note: ', e);
           });
         });
-      }, 200);
+      }, 400);
     },
     displayMessage(message) {
       this.$root.$emit('alert-message', message?.message, message?.type || 'success');


### PR DESCRIPTION
Before this change, when go to notesA and open 3 dots menu and click on print to pdf then open again the same menu, the menu becomes unusable. after this change, the menu should display the actions list.