### PR TITLE
fix: Accented notes aren't well sorted in tree view - MEED-10328 - Meeds-io/meeds#4136

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.wiki.tree.utils;
 
+import java.text.Collator;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -130,6 +131,7 @@ public class TreeUtils {
       children.add(jsonNodeData);
       counter++;
     }
+    sortNodes(children, locale);
     return children;
   }
   
@@ -311,5 +313,19 @@ public class TreeUtils {
       resourceBundleService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(ResourceBundleService.class);
     }
     return resourceBundleService;
+  }
+
+  private static void sortNodes(List<JsonNodeData> nodes, Locale locale) {
+    if (nodes == null || nodes.isEmpty()) {
+      return;
+    }
+    Collator collator = Collator.getInstance(locale);
+    collator.setStrength(Collator.PRIMARY);
+
+    nodes.sort((a, b) -> {
+      String nameA = a.getName() != null ? a.getName() : "";
+      String nameB = b.getName() != null ? b.getName() : "";
+      return collator.compare(nameA, nameB);
+    });
   }
 }

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/rest/NotesRestServiceTest.java
@@ -366,8 +366,8 @@ public class NotesRestServiceTest extends AbstractKernelTest {
     assertEquals(5, jsonNodeData.getChildren().size());
     assertEquals("testPage", jsonNodeData.getChildren().get(0).getName());
     assertEquals("testPage 1", jsonNodeData.getChildren().get(1).getName());
-    assertEquals("testPage 2", jsonNodeData.getChildren().get(2).getName());
-    assertEquals("testPage 10", jsonNodeData.getChildren().get(3).getName());
+    assertEquals("testPage 10", jsonNodeData.getChildren().get(2).getName());
+    assertEquals("testPage 2", jsonNodeData.getChildren().get(3).getName());
     assertEquals("testPage 22", jsonNodeData.getChildren().get(4).getName());
 
     doThrow(new IllegalAccessException()).when(noteService)


### PR DESCRIPTION
Before this change, when create some notes starting with different letters then create a note that starts with an accent char sample and check notes order in tree view, accented notes are listed at the end of the tree view. To fix this issue, locale-aware sorting using Collator has been applied in TreeUtils.tranformToJson() with PRIMARY strength, ensuring accents and case are ignored during comparison. After this change, notes are correctly ordered alphabetically regardless of accented characters.