### PR TITLE
fix: adding fifth icon in notes leads to overlap in breadcrumb - MEED-10329 - Meeds-io/meeds#4130

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotesOverview.vue
@@ -13,8 +13,8 @@
             no-gutters
             class="mb-5">
             <v-col
-              xl="10"
-              lg="10"
+              xl="9"
+              lg="9"
               md="9"
               sm="8"
               cols="6">
@@ -48,8 +48,8 @@
             </v-col>
             <v-col
               id="note-actions-menu"
-              xl="2"
-              lg="2"
+              xl="3"
+              lg="3"
               md="3"
               sm="4"
               cols="6">


### PR DESCRIPTION
Before this change, create a note with a long title caused the title to overlap with action icons (including the AI ​​search icon). To resolve this issue, the cols value has been updated for lg and xl breakpoints. As a result, the breadcrumb layout now displays correctly without overlap.