### PR TITLE
fix: sort children naturally with accent support if not manually sorted - MEED-10342 - Meeds-io/meeds#4154

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1496,7 +1496,7 @@ public class NotesRestService implements ResourceContainer {
   private List<JsonNodeData> getJsonTree(WikiPageParams params, Map<String, Object> context, Identity identity, Locale locale) throws Exception {
     Wiki noteBook = noteBookService.getWikiByTypeAndOwner(params.getType(), params.getOwner());
     WikiTreeNode noteBookNode = new WikiTreeNode(noteBook);
-    noteBookNode.pushDescendants(context, ConversationState.getCurrent().getIdentity().getUserId());
+    noteBookNode.pushDescendants(context, ConversationState.getCurrent().getIdentity().getUserId(), locale);
     return TreeUtils.tranformToJson(noteBookNode, context, identity, locale);
   }
 
@@ -1504,7 +1504,7 @@ public class NotesRestService implements ResourceContainer {
                                                 Map<String, Object> context,
                                                 Identity identity,
                                                 Locale locale) throws Exception {
-    TreeNode treeNode = TreeUtils.getDescendants(params, context, ConversationState.getCurrent().getIdentity().getUserId());
+    TreeNode treeNode = TreeUtils.getDescendants(params, context, ConversationState.getCurrent().getIdentity().getUserId(), locale);
     return TreeUtils.tranformToJson(treeNode, context, identity, locale);
   }
 

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/PageTreeNode.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/PageTreeNode.java
@@ -28,8 +28,6 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.social.core.space.model.Space;
-import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.PermissionType;
 import org.exoplatform.wiki.service.NoteService;
@@ -38,27 +36,25 @@ import org.exoplatform.wiki.tree.utils.TreeUtils;
 import org.exoplatform.wiki.utils.Utils;
 
 public class PageTreeNode extends TreeNode {
+
   private static final Log log = ExoLogger.getLogger(PageTreeNode.class);
 
   @Setter
   @Getter
-  private Page page;
+  private Page             page;
 
-  private NoteService noteService;
-  
-  private SpaceService spaceService;
+  private NoteService      noteService;
 
-  public PageTreeNode(Page page) throws Exception {
+  public PageTreeNode(Page page) {
     super(page.getTitle(), TreeNodeType.PAGE);
 
     this.noteService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(NoteService.class);
-    
-    this.spaceService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(SpaceService.class);
 
     this.page = page;
     this.id = page.getId();
     this.path = buildPath();
     this.hasChild = !page.isDraftPage() && noteService.hasChildren(Long.parseLong(page.getId()));
+    this.position = page.getPosition();
   }
 
   @Override

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/TreeNode.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/TreeNode.java
@@ -18,6 +18,7 @@
  */
 package org.exoplatform.wiki.tree;
 
+import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.comparators.NaturalComparator;
 import org.exoplatform.wiki.model.Page;
@@ -27,7 +28,7 @@ import org.exoplatform.wiki.utils.Utils;
 
 import java.util.*;
 
-
+@Data
 public class TreeNode { 
 
   protected String           name;
@@ -43,6 +44,8 @@ public class TreeNode {
   protected TreeNodeType     nodeType;
 
   protected List<TreeNode>   children        = new ArrayList<TreeNode>();
+
+  protected Integer          position;
 
   final static public String STACK_PARAMS    = "stackParams";
   
@@ -79,66 +82,6 @@ public class TreeNode {
   public TreeNode(String name, TreeNodeType nodeType) {    
     this.name = name;
     this.nodeType = nodeType;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public TreeNodeType getNodeType() {
-    return nodeType;
-  }
-
-  public void setNodeType(TreeNodeType nodeType) {
-    this.nodeType = nodeType;
-  }
-
-  public boolean isHasChild() {
-    return hasChild;
-  }
-
-  public void setHasChild(boolean hasChild) {
-    this.hasChild = hasChild;
-  }
-
-  public List<TreeNode> getChildren() {
-    return children;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public boolean isSelected() {
-    return isSelected;
-  }
-
-  public void setSelected(boolean isSelected) {
-    this.isSelected = isSelected;
-  }
-
-  public void setChildren(List<TreeNode> children) {
-    this.children = children;
-  }
-
-  public String getPath() {
-    return path;
-  }
-  
-  public boolean isRetricted() {
-    return isRetricted;
-  }
-
-  public void setRetricted(boolean isRetricted) {
-    this.isRetricted = isRetricted;
   }
 
   @Override
@@ -180,16 +123,24 @@ public class TreeNode {
     } else if (!nodeType.equals(other.nodeType))
       return false;
     if (path == null) {
-      if (other.path != null)
-        return false;
-    } else if (!path.equals(other.path))
-      return false;
-    return true;
-  } 
-  
-  public void pushDescendants(Map<String, Object> context, String userId) throws Exception {
+      return other.path == null;
+    } else
+      return path.equals(other.path);
+  }
+
+  public void pushDescendants(Map<String, Object> context, String userId, Locale locale) throws Exception {
     addChildren(context, userId);
-    pushChildren(context, userId);
+    pushChildren(context, userId, locale);
+
+    boolean isDefaultSort = this.children.stream()
+            .allMatch(child -> child.getPosition() == null);
+
+    if (isDefaultSort) {
+      // Sort naturally by name only if all positions are null
+      this.children = this.children.stream()
+              .sorted((c1, c2) -> new NaturalComparator(locale).compare(c1.getName(), c2.getName()))
+              .toList();
+    }
   }
   
   protected void addChildren(Map<String, Object> context, String userId) throws Exception {
@@ -209,10 +160,10 @@ public class TreeNode {
     return childrenNUm;
   }
   
-  private void pushChildren(Map<String, Object> context, String userId) throws Exception {
+  private void pushChildren(Map<String, Object> context, String userId, Locale locale) throws Exception {
     Deque<WikiPageParams> paramsStk = (Deque<WikiPageParams>) context.get(STACK_PARAMS);
     if (paramsStk == null) {
-      pushChild(context, userId);
+      pushChild(context, userId, locale);
     } else {
       if (paramsStk.isEmpty()) {
         this.isSelected = true;
@@ -222,23 +173,23 @@ public class TreeNode {
         context.put(STACK_PARAMS, paramsStk);
         if (this instanceof RootTreeNode) {
           SpaceTreeNode spaceNode = new SpaceTreeNode(params.getType());
-          pushChild(spaceNode, context, userId);
+          pushChild(spaceNode, context, userId, locale);
         } else if (this instanceof SpaceTreeNode) {
           Wiki wiki = (Wiki) Utils.getObjectFromParams(params);
           WikiTreeNode wikiNode = new WikiTreeNode(wiki);
-          pushChild(wikiNode, context, userId);
+          pushChild(wikiNode, context, userId, locale);
         } else if (this instanceof WikiTreeNode) {
-          pushChild(context, userId);
+          pushChild(context, userId, locale);
         } else if (this instanceof WikiHomeTreeNode || this instanceof PageTreeNode) {
           Page page = (Page) Utils.getObjectFromParams(params);
           PageTreeNode pageNode = new PageTreeNode(page);
-          pushChild(pageNode, context, userId);
+          pushChild(pageNode, context, userId, locale);
         }
       }
     }
   }
   
-  private void pushChild(TreeNode child, Map<String, Object> context, String userId) throws Exception {
+  private void pushChild(TreeNode child, Map<String, Object> context, String userId, Locale locale) throws Exception {
     Boolean showDesCdt = (Boolean) context.get(SHOW_DESCENDANT);
 
     String depthCdt = (String) context.get(DEPTH);
@@ -253,9 +204,9 @@ public class TreeNode {
         for (int i = 0; i < children.size(); i++) {
           temp = children.get(i);
           if (child == null) {
-            temp.pushDescendants(context, userId);
+            temp.pushDescendants(context, userId, locale);
           } else if (child.equals(temp)) {
-            temp.pushDescendants(context, userId);
+            temp.pushDescendants(context, userId, locale);
             return;
           }
         }
@@ -263,8 +214,8 @@ public class TreeNode {
     }
   }
 
-  private void pushChild(Map<String, Object> context, String userId) throws Exception {
-    pushChild(null, context, userId);
+  private void pushChild(Map<String, Object> context, String userId, Locale locale) throws Exception {
+    pushChild(null, context, userId, locale);
   }
 
   public String buildPath() {

--- a/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
@@ -18,7 +18,6 @@
  */
 package org.exoplatform.wiki.tree.utils;
 
-import java.text.Collator;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -83,9 +82,9 @@ public class TreeUtils {
    * @return <code>TreeNode</code>
    * @throws Exception if error occured
    */
-  public static TreeNode getDescendants(WikiPageParams params, Map<String, Object> context, String userId) throws Exception {
+  public static TreeNode getDescendants(WikiPageParams params, Map<String, Object> context, String userId, Locale locale) throws Exception {
     TreeNode treeNode = getTreeNode(params);
-    treeNode.pushDescendants(context, userId);
+    treeNode.pushDescendants(context, userId, locale);
     return treeNode;
   }
   
@@ -131,7 +130,6 @@ public class TreeUtils {
       children.add(jsonNodeData);
       counter++;
     }
-    sortNodes(children, locale);
     return children;
   }
   
@@ -313,19 +311,5 @@ public class TreeUtils {
       resourceBundleService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(ResourceBundleService.class);
     }
     return resourceBundleService;
-  }
-
-  private static void sortNodes(List<JsonNodeData> nodes, Locale locale) {
-    if (nodes == null || nodes.isEmpty()) {
-      return;
-    }
-    Collator collator = Collator.getInstance(locale);
-    collator.setStrength(Collator.PRIMARY);
-
-    nodes.sort((a, b) -> {
-      String nameA = a.getName() != null ? a.getName() : "";
-      String nameB = b.getName() != null ? b.getName() : "";
-      return collator.compare(nameA, nameB);
-    });
   }
 }


### PR DESCRIPTION
Update pushDescendants() to use improved NaturalComparator for accent-aware sorting of note names when all positions are null.