### PR TITLE
fix: Terms & Conditions can be lost if original language is deleted - MEED-10357 - Meeds-io/meeds#4163

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/rest/TermsAndConditionsRest.java
+++ b/notes-service/src/main/java/io/meeds/notes/rest/TermsAndConditionsRest.java
@@ -77,7 +77,7 @@ public class TermsAndConditionsRest {
           @ApiResponse(responseCode = "404", description = "Resource not found"), })
   public ResponseEntity<TermsAndConditionPage> getTermsAndConditionPage(HttpServletRequest request,
                                                                         @Parameter(description = "User language")
-                                                                        @RequestParam("lang")
+                                                                        @RequestParam(name= "lang", required=false)
                                                                         String lang) {
     TermsAndConditionPage termsAndConditionPage = termsAndConditionsService.getTermsAndConditions(lang);
     if (termsAndConditionPage == null) {
@@ -105,7 +105,7 @@ public class TermsAndConditionsRest {
                                                       @RequestParam("content")
                                                       String content,
                                                       @Parameter(description = "User language")
-                                                      @RequestParam("lang")
+                                                      @RequestParam(name= "lang", required=false)
                                                       String lang) {
     try {
       return termsAndConditionsService.saveTermsAndConditions(content, lang, RestUtils.getCurrentUserAclIdentity());
@@ -181,7 +181,7 @@ public class TermsAndConditionsRest {
     try {
       content = HtmlUtils.transform(content,
                                     new HtmlTransformerContext(ConversationState.getCurrent().getIdentity(),
-                                                               LocaleUtils.toLocale(lang)));
+                                      !lang.isBlank() ? LocaleUtils.toLocale(lang) : null));
       return HTMLSanitizer.sanitize(content);
     } catch (Exception e) {
       LOG.warn("Error sanitizing terms and conditions content", e);

--- a/notes-service/src/main/java/io/meeds/notes/service/TermsAndConditionsService.java
+++ b/notes-service/src/main/java/io/meeds/notes/service/TermsAndConditionsService.java
@@ -139,11 +139,11 @@ public class TermsAndConditionsService {
   @SneakyThrows
   public TermsAndConditionPage getTermsAndConditions(String lang) {
     Page page = noteService.getNoteOfNoteBookByName(TC_NOTE_TYPE, IdentityConstants.SYSTEM, TC_NOTE_NAME);
-    if (page != null && StringUtils.isNotBlank(lang) && !StringUtils.equals(lang, page.getLang())) {
+    if (page != null && !StringUtils.equals(lang, page.getLang())) {
       Page publishedVersion = noteService.getPublishedVersionByPageIdAndLang(Long.parseLong(page.getId()), lang);
       publishedVersion = publishedVersion != null ? publishedVersion
                                                   : noteService.getPublishedVersionByPageIdAndLang(Long.parseLong(page.getId()),
-                                                                                                   Locale.ENGLISH.getLanguage());
+                                                                                                   lang);
       if (publishedVersion != null) {
         page.setTitle(publishedVersion.getTitle());
         page.setContent(publishedVersion.getContent());

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/NoteVersionLanguageIndexingServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/NoteVersionLanguageIndexingServiceConnector.java
@@ -53,9 +53,10 @@ public class NoteVersionLanguageIndexingServiceConnector extends WikiPageIndexin
     if (StringUtils.isBlank(id)) {
       throw new IllegalArgumentException("Id is null");
     }
-    String pageId = id.substring(0, id.indexOf("-"));
-    String lang = id.substring(id.indexOf("-") + 1);
-    PageVersion pageVersion = noteService.getPublishedVersionByPageIdAndLang(Long.parseLong(pageId), lang);
+    String[] data = id.split("-");
+    Long pageId = Long.parseLong(data[0]);
+    String lang = (data.length > 1) ? data[1] : null;
+    PageVersion pageVersion = noteService.getPublishedVersionByPageIdAndLang(pageId, lang);
 
     if (pageVersion == null) {
       LOG.warn("The version language with id {} wasn't found, thus it can't be indexed", id);

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1036,10 +1036,6 @@ public class NoteServiceImpl implements NoteService {
       } catch (Exception e) {
         log.error("Error while saving note version language metadata", e);
       }
-      if (broadcast) {
-        String versionLangId = note.getId() + "-" + note.getLang();
-        postUpdatePageVersionLanguage(versionLangId);
-      }
     } else {
       pageVersion.setId(note.getId() + "-" + pageVersion.getName());
       copyNotePageProperties(note,
@@ -1049,6 +1045,10 @@ public class NoteServiceImpl implements NoteService {
                              NOTE_METADATA_PAGE_OBJECT_TYPE,
                              NOTE_METADATA_VERSION_PAGE_OBJECT_TYPE,
                              userName);
+    }
+    if (broadcast) {
+      String versionLangId = note.getLang()!= null ? note.getId() + "-" + note.getLang() : note.getId();
+      postUpdatePageVersionLanguage(versionLangId);
     }
     broadcastPageVersionCreationEvent(pageVersionId,
                                       draftPage != null ? draftPage.getId() : null,

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -135,6 +135,8 @@ public class NotesRestService implements ResourceContainer {
 
   private static final Log            LOG              = ExoLogger.getLogger(NotesRestService.class);
 
+  public static final String          TC_NOTE_TYPE     = "terms";
+
   private final NoteService           noteService;
 
   private final WikiService           noteBookService;
@@ -742,11 +744,11 @@ public class NotesRestService implements ResourceContainer {
       NotePageProperties currentNodeProperties = note_.getProperties();
       if (!note_.getTitle().equals(note.getTitle()) && !note_.getContent().equals(note.getContent())) {
         if (StringUtils.isBlank(note.getLang())) {
-          newNoteName = TitleResolver.getId(note.getTitle(), false);
           note_.setTitle(note.getTitle());
           note_.setContent(note.getContent());
           note_.setProperties(notePageProperties);
-          if (!NoteConstants.NOTE_HOME_NAME.equals(note.getName()) && !note.getName().equals(newNoteName)) {
+          if (!NoteConstants.NOTE_HOME_NAME.equals(note.getName()) && !note.getName().equals(newNoteName) && !note.getWikiType().equals(TC_NOTE_TYPE)) {
+            newNoteName = TitleResolver.getId(note.getTitle(), false);
             noteService.renameNote(note_.getWikiType(), note_.getWikiOwner(), note_.getName(), newNoteName, note.getTitle());
             note_.setName(newNoteName);
           }
@@ -765,8 +767,9 @@ public class NotesRestService implements ResourceContainer {
         }
       } else if (!note_.getTitle().equals(note.getTitle())) {
         if (StringUtils.isBlank(note.getLang())) {
-          newNoteName = TitleResolver.getId(note.getTitle(), false);
-          if (!NoteConstants.NOTE_HOME_NAME.equals(note.getName()) && !note.getName().equals(newNoteName)) {
+
+          if (!NoteConstants.NOTE_HOME_NAME.equals(note.getName()) && !note.getName().equals(newNoteName) && !note.getWikiType().equals(TC_NOTE_TYPE)) {
+            newNoteName = TitleResolver.getId(note.getTitle(), false);
             noteService.renameNote(note_.getWikiType(), note_.getWikiOwner(), note_.getName(), newNoteName, note.getTitle());
             note_.setName(newNoteName);
           }

--- a/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/js/TermsAndConditionsService.js
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/js/TermsAndConditionsService.js
@@ -18,7 +18,13 @@
  */
 
 export function getTermsAndConditions(lang) {
-  return fetch(`/notes/rest/terms?lang=${lang|| 'en'}`, {
+  const formData = new FormData();
+  if (lang) {
+    formData.append('lang', lang);
+  }
+  const urlParams = new URLSearchParams(formData).toString();
+  const params = urlParams.length && `?${decodeURIComponent(urlParams)}` || '';
+  return fetch(`/notes/rest/terms${params}`, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {


### PR DESCRIPTION
Before this change, when go to Terms & Conditions settings then create a notes and save content and update the created notes and click on translation: choose original and delete the language displayed then save the notes, Terms & Conditions is reset and content lost. To fix this problem, change in the rest of the Terms & Conditions to be registered when the lang is null. After this change, Terms & Conditions is saved even if the language is null.