### PR TITLE
fix: prevent XSS vulnerability in note search result - EXO-86230

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -1323,7 +1323,7 @@ public class NotesRestService implements ResourceContainer {
                             "all")
                             : null;
             NoteSearchResult noteSearchResult = new NoteSearchResult();
-            noteSearchResult.setTitle(searchResult.getTitle());
+            noteSearchResult.setTitle(HTMLSanitizer.sanitize(searchResult.getTitle()));
             noteSearchResult.setId(page.getId());
             noteSearchResult.setPageName(page.getName());
             noteSearchResult.setPageName(page.getName());


### PR DESCRIPTION
Before this change, the note search result title was vulnerable to XSS attacks. This update introduces sanitization to prevent such vulnerabilities