### PR TITLE
feat: Add ContentType Definition in Search Connector - EXO-86376

### DIFF
--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/search-configuration.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/search-configuration.xml
@@ -37,6 +37,9 @@
             <field name="name">
               <string>notes</string>
             </field>
+            <field name="contentType">
+              <string>notes</string>
+            </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/notes/contextsearch?limit={limit}&keyword={keyword}]]></string>
             </field>


### PR DESCRIPTION
This change will allow to define the associated `contentType` for each Search Connector to allow automatic filtering on content types.