### PR TITLE
fix: Terms & Conditions can be lost if original language is deleted - MEED-10357 - Meeds-io/meeds#4163

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/service/TermsAndConditionsService.java
+++ b/notes-service/src/main/java/io/meeds/notes/service/TermsAndConditionsService.java
@@ -124,7 +124,7 @@ public class TermsAndConditionsService {
       String storedLatestVersionId = metadataItem.getProperties().get(PUBLISHED_VERSION_ID);
       metadataItem.setProperties(settings);
       metadataService.updateMetadataItem(metadataItem, Long.parseLong(page.getId()), false);
-      eventName = !page.getLatestVersionId().equals(storedLatestVersionId) ? EVENT_NAME_UPDATED : null;
+      eventName = page.getLatestVersionId() != null && !page.getLatestVersionId().equals(storedLatestVersionId) ? EVENT_NAME_UPDATED : null;
     } else {
       MetadataObject metadataObject = new MetadataObject(TC_METADATA_OBJECT_TYPE, page.getId());
       metadataService.createMetadataItem(metadataObject, TC_METADATA_KEY, settings, Long.parseLong(page.getId()));

--- a/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/components/TermsAndConditionsDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/components/TermsAndConditionsDrawer.vue
@@ -179,7 +179,7 @@ export default {
     },
     updatePublishedSetting() {
       this.loading = true;
-      return this.$termsAndConditionsService.updateTermsAndConditionsSettings(this.published, this.lang)
+      return this.$termsAndConditionsService.updateTermsAndConditionsSettings(this.published, this.note.lang)
         .then(() => this.retrieveTerms())
         .then(() => {
           if (this.published) {

--- a/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/js/TermsAndConditionsService.js
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-admin-settings/js/TermsAndConditionsService.js
@@ -62,7 +62,7 @@ export function saveTermsAndConditions(content, lang) {
 }
 
 export function updateTermsAndConditionsSettings(published, lang) {
-  return fetch(`/notes/rest/terms/settings?published=${published || false}&lang=${lang || 'en'}`, {
+  return fetch(`/notes/rest/terms/settings?published=${published || false}&lang=${lang}`, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-user-settings/components/TermsAndConditionsUserSettings.vue
+++ b/notes-webapp/src/main/webapp/vue-app/terms-and-conditions-user-settings/components/TermsAndConditionsUserSettings.vue
@@ -52,7 +52,7 @@ export default {
     id: `Settings${parseInt(Math.random() * 10000)
       .toString()
       .toString()}`,
-    language: eXo.env.portal.language,
+    lang: eXo.env.portal.language,
     displayed: true,
     displayDetails: false,
     termsAndConditionsLinkBasePath: `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/settings#terms-and-conditions`,


### PR DESCRIPTION
Before this change, when go to Terms & Conditions settings then create a notes and save content and update the created notes and click on translation: choose original and delete the language displayed then save the notes, Terms & Conditions is reset and content lost. To fix this problem, change in the rest of the Terms & Conditions to be registered when the lang is null. After this change, Terms & Conditions is saved even if the language is null.