### PR TITLE
feat: Trigger page update event on page moving - EXO-86812 - Meeds-io/ai#209

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageIndexingListener.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageIndexingListener.java
@@ -18,10 +18,15 @@
  */
 package org.exoplatform.wiki.jpa.search;
 
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+
 import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.wiki.WikiException;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.PageVersion;
+import org.exoplatform.wiki.service.NoteService;
 import org.exoplatform.wiki.service.PageUpdateType;
 import org.exoplatform.wiki.service.listener.PageWikiListener;
 
@@ -30,9 +35,13 @@ import org.exoplatform.wiki.service.listener.PageWikiListener;
  */
 public class PageIndexingListener extends PageWikiListener {
 
+  private NoteService     noteService;
+
   private IndexingService indexingService;
 
-  public PageIndexingListener(IndexingService indexingService) {
+  public PageIndexingListener(IndexingService indexingService,
+                              NoteService noteService) {
+    this.noteService = noteService;
     this.indexingService = indexingService;
   }
 
@@ -47,8 +56,12 @@ public class PageIndexingListener extends PageWikiListener {
                              String pageId,
                              Page page,
                              PageUpdateType wikiUpdateType) throws WikiException {
-    if (!page.isDraftPage()) {
-      indexingService.reindex(WikiPageIndexingServiceConnector.TYPE, page.getId());
+    if (page != null && !page .isDeleted() && !page.isDraftPage()) {
+      if (wikiUpdateType == PageUpdateType.MOVE_PAGE) {
+        reindexPageTree(page);
+      } else {
+        indexingService.reindex(WikiPageIndexingServiceConnector.TYPE, page.getId());
+      }
     }
   }
 
@@ -67,4 +80,13 @@ public class PageIndexingListener extends PageWikiListener {
     String pageVersionId = pageVersion.getParent().getId() + "-" + pageVersion.getLang();
     indexingService.unindex(NoteVersionLanguageIndexingServiceConnector.TYPE, pageVersionId);
   }
+
+  private void reindexPageTree(Page page) {
+    indexingService.reindex(WikiPageIndexingServiceConnector.TYPE, page.getId());
+    List<Page> children = noteService.getChildrenNoteOf(page, false, false);
+    if (CollectionUtils.isNotEmpty(children)) {
+      children.forEach(this::reindexPageTree);
+    }
+  }
+
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1905,6 +1905,15 @@ public class NoteServiceImpl implements NoteService {
       throw new IllegalAccessException("User does not have edit the note.");
     }
     dataStorage.updateNotesPosition(noteReorder);
+    Page updatedPage = getNoteById(noteReorder.getPageId());
+    PageUpdateType updateType = StringUtils.equals(existingNote.getParentPageId(),
+                                                   updatedPage.getParentPageId()) ? PageUpdateType.EDIT_PAGE_PROPERTIES :
+                                                                                  PageUpdateType.MOVE_PAGE;
+    postUpdatePage(updatedPage.getWikiType(),
+                   updatedPage.getWikiOwner(),
+                   updatedPage.getName(),
+                   new Page(updatedPage),
+                   updateType);
   }
 
   /******* Private methods *******/


### PR DESCRIPTION
This change will allow to trigger an event when reordering Note pages which will allow to update indexes by example.

Resolves Meeds-io/ai#209