### PR TITLE
fix: Replace placeholder image with clipboard icon when the space has no children - EXO-87235_EXO-87317

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
@@ -212,16 +212,12 @@
             element="div"
             class="position-sticky d-flex me-1 ms-auto" />
         </div>
-        <div v-else-if="!hasChildren || hasDraft && hasEmptyContent">
-          <div v-if="isManager" class="d-flex flex-column justify-center text-center">
-            <v-img
-              :src="emptyNoteNoManager"
-              class="mx-auto mb-4"
-              max-height="150"
-              max-width="250"
-              contain
-              eager />
-            <div>
+        <div class="mt-12" v-else-if="noteChildren && !hasChildren || hasDraft && hasEmptyContent">
+          <div class="d-flex flex-column justify-center text-center">
+            <v-icon size="60" class="tertiary-color">
+              fa-clipboard
+            </v-icon>
+            <div v-if="isManager" class="mt-5">
               <p class="notes-welcome-patragraph">
                 <span>{{ $t('notes.label.no-content-no-redactor.content.first') }}</span>
                 <v-tooltip bottom>
@@ -261,16 +257,7 @@
                 </v-tooltip>
               </p>
             </div>
-          </div>
-          <div v-else class="d-flex flex-column justify-center text-center text-color">
-            <v-img
-              :src="emptyNoteWithManager"
-              class="mx-auto mb-4"
-              max-height="150"
-              max-width="250"
-              contain
-              eager />
-            <div>
+            <div v-else-if="note.id" class="mt-5">
               <h4 class="notes-welcome-title font-weight-bold text-color">
                 {{ $t('notes.label.no-content-redactor-title').replace('{0}', spaceDisplayName) }}
               </h4>
@@ -284,7 +271,6 @@
             </div>
           </div>
         </div>
-
         <div v-else>
           <v-treeview
             v-if="noteChildren?.length"
@@ -427,7 +413,7 @@ export default {
       actualVersion: {},
       noteContent: '',
       displayLastVersion: true,
-      noteChildren: [],
+      noteChildren: null,
       isDraft: false,
       noteTitle: '',
       noteSummary: '',


### PR DESCRIPTION
Prior to this change, when a space note had no child notes, two different placeholder images were displayed depending on whether the connected user can redact on the space or not.
With this commit, these placeholder images are replaced by a single clipboard icon for both cases.