### PR TITLE
fix: Fix Notes editor application display issue in edit layout mode - EXO-87312

### DIFF
--- a/notes-webapp/src/main/webapp/skin/less/notes/notes.less
+++ b/notes-webapp/src/main/webapp/skin/less/notes/notes.less
@@ -56,7 +56,9 @@
   .notes-editor-body-section {
     padding-top: 10px;
     padding-bottom: 10px;
-    width: 100%;
+    max-width: 1320px;
+    margin-left: auto;
+    margin-right: auto;
     .notes-editor-body-section-content {
       width: @pageWidth;
       max-width: 100%;
@@ -72,10 +74,8 @@
     }
   }
   #notesEditor {
-    position: fixed;
     height: 100%;
     top: 0;
-    z-index: 1031;
     background: #eeeeee;
 
     .notes-content-wrapper {
@@ -83,7 +83,7 @@
     }
 
     .notes-content {
-      height: ~"calc(var(--100vh, 100vh) - 100px)";
+      height: ~"calc(var(--100vh, 100vh) - 136px)";
       overflow: auto;
       z-index: 5;
       background-color: #eeeeee;


### PR DESCRIPTION
Prior to this change, the Notes editor application is not well displayed centered in edit layout mode.
After this commit, some css changes are done in order to adjust the display position of the the Notes editor application.