### PR TITLE
fix: Fix publication when editing the scheduling option from between to until - EXO-87309

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -221,6 +221,10 @@ export default {
       type: Boolean,
       default: true
     },
+    editMode: {
+      type: Boolean,
+      default: true
+    },
     imagesDownloadFolder: {
       type: String,
       default: 'DRIVE_ROOT_NODE/notes/images'
@@ -299,12 +303,6 @@ export default {
     },
     isContentImagesUploadProgress() {
       return this.contentImageUploadProgress;
-    },
-    newPageDraft() {
-      return !this.noteObject?.id || (this.noteObject?.draftPage && !this.noteObject?.targetPageId);
-    },
-    editMode() {
-      return this.noteObject?.id && !this.newPageDraft;
     },
     isTranslation() {
       return !!this.noteObject?.lang;


### PR DESCRIPTION
Prior to this change, when editing the scheduling option from between to until, no immediate publication is done for the article. After this commit, we ensure to publish the article immediately when switching schedule option from between to until.