### PR TITLE
fix: Fix cancelling the unpublishing of an article makes it a draft and creates empty activity - EXO-87191

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-publication/components/schedule-option/NoteScheduleOption.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-publication/components/schedule-option/NoteScheduleOption.vue
@@ -348,10 +348,8 @@ export default {
     handleMultiSelectionUpdate() {
       if (this.isMultipleSelectionOption) {
         this.editScheduleOption = [SCHEDULE_OPTION, PUBLISH_NOW_OPTION];
-      } else if (this.isUntilScheduleType) {
-        this.editScheduleOption = CANCEL_SCHEDULE_OPTION;
       } else {
-        this.editScheduleOption = this.editScheduleOption[0];
+        this.editScheduleOption = this.editScheduleOption && this.editScheduleOption[0];
       }
     },
     handleEditScheduleOptionUpdate() {


### PR DESCRIPTION
Prior to this change, when an article is published until an end date unpublished and without refreshing the page its publication is saved, the article is converted to a draft and its related activity becomes empty as if we have canceled the scheduling of a scheduled article.
After this commit, the aggressive fallback condition that forced CANCEL_SCHEDULE_OPTION whenever the schedule type was 'until' has been removed from handleMultiSelectionUpdate(). Since the 'publish now' feature is no longer existent, this multi-selection fallback logic was obsolete and caused accidental draft conversions by overwriting the correct 'schedule' option state when reopening the drawer without a page refresh.