### PR TITLE
fix: Display restricted area placeholder instead of notes editor or news editor when the current user can not redact on the space - EXO-87648

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -17,6 +17,9 @@ notes.menu.label.noteHistory=Note History
 notes.menu.label.duplicate=Duplicate
 notes.menu.label.copyOf=Copy of
 notes.button.import=Import
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
 
 
 notes.menu.label.import=Import

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -46,6 +46,7 @@
       :save-button-disabled="saveOrUpdateDisabled"
       :editor-body-input-ref="'notesContent'"
       :editor-title-input-ref="'noteTitle'"
+      :can-redact="canRedact"
       @open-treeview="openTreeView"
       @post-note="postNote"
       @auto-save="autoSave"
@@ -136,7 +137,8 @@ export default {
       wikiDraftObjectType: 'wikiDraft',
       wikiPageObjectType: 'wikiPage',
       autosaveProcessedFromEditorExtension: false,
-      extensionDataUpdated: false
+      extensionDataUpdated: false,
+      canRedact: null
     };
   },
   computed: {
@@ -195,9 +197,13 @@ export default {
         this.autoSave();
       }
     },
-  },
-  mounted() {
-    this.init();
+    canRedact(newVal) {
+      if (newVal !== null) {
+        this.$nextTick(() => {
+          this.$refs.editor?.initCKEditor();
+        });
+      }
+    }
   },
   created() {
     this.refreshTranslationExtensions();
@@ -268,11 +274,13 @@ export default {
   },
   methods: {
     getTargetSpaceId(groupId) {
-      if (this.spaceId || !groupId) {
+      if (!groupId) {
+        this.canRedact = true;
         return;
       }
       this.$spaceService.getSpaceByGroupId(groupId).then((space) => {
         this.targetSpaceId = space?.id;
+        this.canRedact = space.canRedactOnSpace;
       });
     },
     processAutoSaveFromEditorExtension(event) {

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -18,85 +18,89 @@
 -->
 
 <template>
-  <div
-    id="notesEditor"
-    class="notesEditor width-full">
-    <note-editor-top-bar
-      :note="note"
-      :languages="languages"
-      :form-title="formTitle"
-      :note-id-param="noteIdParam"
-      :web-page-note="webPageNote"
-      :selected-language="selectedLanguage"
-      :translations="translations"
-      :is-mobile="isMobile"
-      :post-key="postKey + enablePostKeys"
-      :draft-saving-status="draftSavingStatus"
-      :publish-button-text="publishButtonText"
-      :lang-button-tooltip-text="langButtonTooltipText"
-      :web-page-url="webPageUrl"
-      :editor-icon="resolvedEditorIcon"
-      :save-button-icon="saveButtonIcon"
-      :save-button-disabled="saveNoteButtonDisabled"
-      :editor-ready="!!editor"
-      @editor-closed="editorClosed"
-      @post-note="postNote"
-      @open-metadata-drawer="openMetadataDrawer" />
-    <div class="notes-editor-body-section">
-      <div class="notes-editor-body-section-content">
-        <form class="notes-content">
-          <div class="notes-content-form">
-            <div
-              v-show="!webPageNote"
-              class="formInputGroup title notesTitle white px-5 pt-5 ">
-              <input
-                id="notesTitle"
-                :ref="editorTitleInputRef"
-                v-model="noteObject.title"
-                :placeholder="editorTitlePlaceHolder"
-                :maxlength="noteTitleMaxLength + 1"
-                type="text"
-                class="title text-color ma-0 pa-0"
-                @input="waitUserTyping()"
-                @keydown.enter.prevent="focusEditor">
-            </div>
-            <div class="formInputGroup white overflow-auto flex notes-content-wrapper px-5 pb-5">
-              <textarea
-                :id="editorBodyInputRef"
-                :ref="editorBodyInputRef"
-                :placeholder="editorBodyPlaceHolder"
-                :name="editorBodyInputRef"
-                class="notesFormInput">
+  <div v-if="canRedact !== null">
+    <note-restricted-editor v-if="!canRedact" />
+    <div
+      v-else
+      id="notesEditor"
+      class="notesEditor width-full">
+      <note-editor-top-bar
+        :note="note"
+        :languages="languages"
+        :form-title="formTitle"
+        :note-id-param="noteIdParam"
+        :web-page-note="webPageNote"
+        :selected-language="selectedLanguage"
+        :translations="translations"
+        :is-mobile="isMobile"
+        :post-key="postKey + enablePostKeys"
+        :draft-saving-status="draftSavingStatus"
+        :publish-button-text="publishButtonText"
+        :lang-button-tooltip-text="langButtonTooltipText"
+        :web-page-url="webPageUrl"
+        :editor-icon="resolvedEditorIcon"
+        :save-button-icon="saveButtonIcon"
+        :save-button-disabled="saveNoteButtonDisabled"
+        :editor-ready="!!editor"
+        @editor-closed="editorClosed"
+        @post-note="postNote"
+        @open-metadata-drawer="openMetadataDrawer" />
+      <div class="notes-editor-body-section">
+        <div class="notes-editor-body-section-content">
+          <form class="notes-content">
+            <div class="notes-content-form">
+              <div
+                v-show="!webPageNote"
+                class="formInputGroup title notesTitle white px-5 pt-5 ">
+                <input
+                  id="notesTitle"
+                  :ref="editorTitleInputRef"
+                  v-model="noteObject.title"
+                  :placeholder="editorTitlePlaceHolder"
+                  :maxlength="noteTitleMaxLength + 1"
+                  type="text"
+                  class="title text-color ma-0 pa-0"
+                  @input="waitUserTyping()"
+                  @keydown.enter.prevent="focusEditor">
+              </div>
+              <div class="formInputGroup white overflow-auto flex notes-content-wrapper px-5 pb-5">
+                <textarea
+                  :id="editorBodyInputRef"
+                  :ref="editorBodyInputRef"
+                  :placeholder="editorBodyPlaceHolder"
+                  :name="editorBodyInputRef"
+                  class="notesFormInput">
             </textarea>
+              </div>
             </div>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
+      <extension-registry-components
+        v-if="editorExtensions.length > 0"
+        name="NotesRichEditor"
+        type="notes-editor-extensions"
+        :params="extensionParams" />
+      <note-editor-metadata-drawer
+        ref="editorMetadataDrawer"
+        :has-featured-image="hasFeaturedImage"
+        @metadata-updated="metadataUpdated" />
+      <note-editor-featured-image-drawer
+        ref="featuredImageDrawer"
+        :note="noteObject"
+        :has-featured-image="hasFeaturedImage" />
+      <note-publication-drawer
+        v-if="publicationParams"
+        ref="editorPublicationDrawer"
+        :has-featured-image="hasFeaturedImage"
+        :is-publishing="isPublishing"
+        :params="publicationParams"
+        :edit-mode="editMode"
+        @publish="postAndPublishNote"
+        @metadata-updated="metadataUpdated"
+        @closed="publicationDrawerClosed" />
+      <note-publication-target-drawer />
     </div>
-    <extension-registry-components
-      v-if="editorExtensions.length > 0"
-      name="NotesRichEditor"
-      type="notes-editor-extensions"
-      :params="extensionParams" />
-    <note-editor-metadata-drawer
-      ref="editorMetadataDrawer"
-      :has-featured-image="hasFeaturedImage"
-      @metadata-updated="metadataUpdated" />
-    <note-editor-featured-image-drawer
-      ref="featuredImageDrawer"
-      :note="noteObject"
-      :has-featured-image="hasFeaturedImage" />
-    <note-publication-drawer
-      v-if="publicationParams"
-      ref="editorPublicationDrawer"
-      :has-featured-image="hasFeaturedImage"
-      :is-publishing="isPublishing"
-      :params="publicationParams"
-      :edit-mode="editMode"
-      @publish="postAndPublishNote"
-      @metadata-updated="metadataUpdated"
-      @closed="publicationDrawerClosed" />
-    <note-publication-target-drawer />
   </div>
 </template>
 
@@ -235,6 +239,10 @@ export default {
     },
     targetSpaceId: {
       type: Number,
+      default: null
+    },
+    canRedact: {
+      type: Boolean,
       default: null
     }
   },

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/RestrictedNoteEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/RestrictedNoteEditor.vue
@@ -1,0 +1,59 @@
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+-->
+
+<template>
+  <v-app class="application-body">
+    <v-card
+      class="py-12 text-center"
+      color="transparent"
+      flat>
+      <v-card-text>
+        <v-icon color="primary" class="fa-7x">
+          fa-edit
+        </v-icon>
+      </v-card-text>
+      <v-card-text class="text-h5 text-subtitle">
+        {{ $t('notes.editor.restrictedTitle') }}
+      </v-card-text>
+      <v-card-text class="text-h5 text-subtitle">
+        {{ $t('notes.editor.restrictedDescription') }}
+      </v-card-text>
+      <v-card-actions class="justify-center py-5">
+        <v-btn
+          :href="defaultLink"
+          color="primary"
+          class="btn">
+          <span class="text-none">{{ $t('notes.editor.restrictedButton') }}</span>
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-app>
+</template>
+<script>
+export default {
+  computed: {
+    defaultLink() {
+      return `${eXo.env.portal.context}`;
+    },
+  },
+  mounted() {
+    this.$root.$applicationLoaded();
+  },
+};
+</script>

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/initComponents.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/initComponents.js
@@ -1,6 +1,7 @@
 import TranslationsEditBar from '../notes-rich-editor/components/TranslationsEditBar.vue';
 import NoteEditorTopBar from '../notes-rich-editor/components/NoteEditorTopBar.vue';
 import NoteFullRichEditor from './components/NoteFullRichEditor.vue';
+import RestrictedNoteEditor from './components/RestrictedNoteEditor.vue';
 import NoteEditorMetadataDrawer from './components/note-properties/NoteEditorMetadataDrawer.vue';
 import NoteEditorFeaturedImageDrawer from './components/note-properties/NoteEditorFeaturedImageDrawer.vue';
 import NoteMetadataPropertiesForm from './components/note-properties/NoteMetadataPropertiesForm.vue';
@@ -9,6 +10,7 @@ const components = {
   'note-translation-edit-bar': TranslationsEditBar,
   'note-editor-top-bar': NoteEditorTopBar,
   'note-full-rich-editor': NoteFullRichEditor,
+  'note-restricted-editor': RestrictedNoteEditor,
   'note-editor-metadata-drawer': NoteEditorMetadataDrawer,
   'note-editor-featured-image-drawer': NoteEditorFeaturedImageDrawer,
   'note-metadata-properties-form': NoteMetadataPropertiesForm


### PR DESCRIPTION
Prior to this change, when the connected user can not redact on the current space, the notes-editor and news-editor pages are accessible with errors when creating note or article. 
After this commit, a restricted area placeholder will be displayed instead of notes editor and news editor when the connected user can not redact on the current space.
