### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/listener/AnalyticsAddTagListener.java
+++ b/notes-service/src/main/java/io/meeds/notes/listener/AnalyticsAddTagListener.java
@@ -58,9 +58,9 @@ public class AnalyticsAddTagListener extends Listener<TagObject, Set<TagName>> {
       statisticData.setOperation("Add tag");
       statisticData.setTimestamp(new Date().getTime());
       statisticData.setUserId(userId);
-      statisticData.addParameter("username", currentUser);
-      statisticData.addParameter("dataType", StringUtils.lowerCase(tagObject.getType()));
-      statisticData.addParameter("spaceId", tagObject.getSpaceId());
+      statisticData.addKeyword("username", currentUser);
+      statisticData.addKeyword("dataType", StringUtils.lowerCase(tagObject.getType()));
+      statisticData.setSpaceId(tagObject.getSpaceId());
 
       for (int i = 0; i < numberOfTags; i++) {
         AnalyticsUtils.addStatisticData(statisticData);

--- a/notes-service/src/main/java/org/exoplatform/notes/listener/analytics/NotesPageListener.java
+++ b/notes-service/src/main/java/org/exoplatform/notes/listener/analytics/NotesPageListener.java
@@ -159,21 +159,21 @@ public class NotesPageListener extends PageWikiListener {
       if (page instanceof PageVersion) {
         contentId = page.getParent().getId();
       }
-      statisticData.addParameter("contentId", contentId);
-      statisticData.addParameter("contentTitle", page.getTitle());
+      statisticData.addKeyword("contentId", contentId);
+      statisticData.addKeyword("contentTitle", page.getTitle());
       if (!operation.equals(WIKI_ADD_PAGE_OPERATION)) {
-        statisticData.addParameter("contentLanguage", page.getLang() != null ? page.getLang() : "originalVersion");
+        statisticData.addKeyword("contentLanguage", page.getLang() != null ? page.getLang() : "originalVersion");
       }
-      statisticData.addParameter("contentCreator", page.getAuthor());
+      statisticData.addKeyword("contentCreator", page.getAuthor());
       String lastModifier = page.getLastUpdater();
       if (lastModifier == null) {
         PageVersion pageVersion = getNoteService().getPublishedVersionByPageIdAndLang(Long.valueOf(page.getId()), page.getLang());
         lastModifier = Objects.requireNonNullElse(pageVersion, page).getAuthor();
       }
-      statisticData.addParameter("contentLastModifier", lastModifier);
-      statisticData.addParameter("contentType", "Note");
-      statisticData.addParameter("contentUpdatedDate", page.getUpdatedDate());
-      statisticData.addParameter("contentCreationDate", page.getCreatedDate());
+      statisticData.addKeyword("contentLastModifier", lastModifier);
+      statisticData.addKeyword("contentType", "Note");
+      statisticData.addDate("contentUpdatedDate", page.getUpdatedDate());
+      statisticData.addDate("contentCreationDate", page.getCreatedDate());
 
       if (StringUtils.isNotBlank(wikiOwner) && StringUtils.equalsIgnoreCase(WikiType.GROUP.name(), wikiType)) {
         Space space = getSpaceService().getSpaceByGroupId(wikiOwner);


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.