### PR TITLE
fix: Accessibility -  The image of Hide/display treeview has no label  - EXO-87382

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
@@ -39,24 +39,20 @@
       @filter-button-click="$root.$emit('notes-filter-open', filter)"
       @filter-expand="filterExpand = $event"
       @loading="$emit('loading', $event)" />
-    <v-tooltip v-if="!filterExpand" bottom>
-      <template #activator="{ on, attrs }">
-        <v-btn
-          icon
-          v-bind="attrs"
-          v-on="on"
-          @click.stop.prevent="$root.$emit('sidebar-tree-view-expend', false)">
-          <img
-            src="/social/images/sidebar.svg"
-            class="icon-default-color"
-            height="20px"
-            width="20px">
-        </v-btn>
-      </template>
-      <span class="caption">
-        {{ $t('notes.tooltip.close.tree') }}
-      </span>
-    </v-tooltip>
+    <v-btn
+      v-if="!filterExpand"
+      icon
+      v-bind="attrs"
+      v-on="on"
+      @click.stop.prevent="$root.$emit('sidebar-tree-view-expend', false)">
+      <img
+        alt=""
+        :title="$t('notes.tooltip.close.tree')"
+        src="/social/images/sidebar.svg"
+        class="icon-default-color"
+        height="20px"
+        width="20px">
+    </v-btn>
   </div>
 </template>
 <script>

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
@@ -40,25 +40,21 @@
               sm="8"
               cols="6">
               <div v-if="!hideElementsForSavingPDF" class="notes-treeview d-flex flex-grow-1">
-                <v-tooltip v-if="!treeViewExpended || isMobile" bottom>
-                  <template #activator="{ on, attrs }">
-                    <v-btn
-                      icon
-                      v-bind="attrs"
-                      v-on="on"
-                      class="pa-0 me-2"
-                      @click.stop.prevent="openSidebarTreeView">
-                      <img
-                        src="/social/images/sidebar.svg"
-                        class="icon-default-color"
-                        height="20px"
-                        width="20px">
-                    </v-btn>
-                  </template>
-                  <span class="caption">
-                    {{ $t('notes.tooltip.open.tree') }}
-                  </span>
-                </v-tooltip>
+                <v-btn
+                  v-if="!treeViewExpended || isMobile"
+                  icon
+                  v-bind="attrs"
+                  v-on="on"
+                  class="pa-0 me-2"
+                  @click.stop.prevent="openSidebarTreeView">
+                  <img
+                    alt=""
+                    :title="$t('notes.tooltip.open.tree')"
+                    src="/social/images/sidebar.svg"
+                    class="icon-default-color"
+                    height="20px"
+                    width="20px">
+                </v-btn>
                 <note-breadcrumb
                   class="my-auto"
                   :note-breadcrumb="notebreadcrumb"


### PR DESCRIPTION
Prior to this fix, the Hide/display treeview button contained an image without an alt property.
This commit resolves the accessibility issue by adding alt and title properties to the image.