### PR TITLE
Fix knowledge base auto-import: subspace template and deletion order

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/NotesAutoImportService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/NotesAutoImportService.java
@@ -296,7 +296,12 @@ public class NotesAutoImportService implements Startable {
     space.setPrettyName(prettyName);
     space.setVisibility(Space.HIDDEN);
     space.setRegistration(Space.CLOSED);
-    Optional<SpaceTemplate> communitySpaceTemplate = spaceTemplateService.getSpaceTemplates().stream().filter(template -> template.getLayout().equals("community")).findFirst();
+    List<Long> subspaceTemplateIds = spaceTemplateService.getSubspaceTemplateIds(superUserIdentity.getUserId());
+    Optional<SpaceTemplate> communitySpaceTemplate = spaceTemplateService.getSpaceTemplates()
+                                                                         .stream()
+                                                                         .filter(template -> template.getLayout().equals("community"))
+                                                                         .filter(template -> !subspaceTemplateIds.contains(template.getId()))
+                                                                         .findFirst();
     if (communitySpaceTemplate.isPresent()) {
       space.setTemplateId(communitySpaceTemplate.get().getId());
     } else {

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -424,7 +424,7 @@ public class NoteServiceImpl implements NoteService {
 
     Page note = getNoteOfNoteBookByName(wikiType, wikiOwner, noteName);
     if (note == null) {
-      log.error("Can't delete note '" + noteName + "'. This note does not exist.");
+      log.warn("Can't delete note '" + noteName + "'. This note does not exist.");
       throw new EntityNotFoundException("Note to delete not found");
     } else if (userIdentity == null || !canEditNote(note, userIdentity.getUserId())) {
       throw new IllegalAccessException("User does not have edit permissions on the note.");
@@ -1352,6 +1352,7 @@ public class NoteServiceImpl implements NoteService {
       Wiki wiki = wikiService.getWikiByTypeAndOwner(parent.getWikiType(), parent.getWikiOwner());
       if (StringUtils.isNotEmpty(conflict) && (conflict.equals("replaceAll"))) {
         List<Page> notesTodelete = getAllNotes(parent);
+        Collections.reverse(notesTodelete);
         for (Page noteTodelete : notesTodelete) {
           if (!NoteConstants.NOTE_HOME_NAME.equals(noteTodelete.getName()) && !noteTodelete.getId().equals(parent.getId())) {
             try {


### PR DESCRIPTION
### Fixes

1. **Filter out subspace templates when creating knowledge base spaces**
   - Knowledge base spaces were failing to create when the selected community template was a subspace template (template 3). Added filtering via `getSubspaceTemplateIds()` to ensure only top-level templates are used.

2. **Prevent EntityNotFoundException noise during notes import**
   - Reversed note deletion order so children are deleted before parents, preventing cascade-related EntityNotFoundException.
   - Downgraded `deleteNote`'s pre-throw log from ERROR to WARN since the exception is the proper error signal and callers handle it.