### PR TITLE
fix: Add mising parent v-app in Portlet - EXO-87831

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes/main.js
@@ -43,7 +43,11 @@ export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready
     Vue.createApp({
-      template: `<notes-overview id="${appId}" />`,
+      template: `
+        <v-app id="${appId}">
+          <notes-overview class="application-body" />
+        </v-app>
+      `,
       vuetify: Vue.prototype.vuetifyOptions,
       i18n,
       computed: {


### PR DESCRIPTION
PRior to this change, the Notes Application is missing the 'v-app' element as parent Vuetify Element. This change will add it.