### PR TITLE
fix: Fix loading save button when creating or editing notes with content links - EXO-87310

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -47,6 +47,7 @@
       :editor-body-input-ref="'notesContent'"
       :editor-title-input-ref="'noteTitle'"
       :can-redact="canRedact"
+      :is-posting="postingNote"
       @open-treeview="openTreeView"
       @post-note="postNote"
       @auto-save="autoSave"
@@ -143,7 +144,7 @@ export default {
   },
   computed: {
     saveOrUpdateDisabled() {
-      return this.notValidTitle || (this.noteNotModified
+      return this.notValidTitle || this.postingNote || (this.noteNotModified
                                 && !this.propertiesModified && !this.draftNote && !this.note.draftPage) || this.savingDraft;
     },
     notValidTitle() {

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteEditorTopBar.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteEditorTopBar.vue
@@ -85,6 +85,7 @@
           <p class="draftSavingStatus my-auto me-3">{{ draftSavingStatus }}</p>
           <v-btn
             v-if="!isMobile"
+            :loading="isPosting"
             id="notesUpdateAndPost"
             class="btn btn-primary primary px-2 py-0 me-5"
             height="34"
@@ -96,6 +97,7 @@
           </v-btn>
           <div v-else class="d-flex">
             <v-btn
+              :loading="isPosting"
               class="btn btn-primary pa-0"
               width="42"
               height="36"
@@ -214,6 +216,10 @@ export default {
       type: Boolean,
       default: false
     },
+    isPosting: {
+      type: Boolean,
+      default: false
+    }
   },
   computed: {
     editorMetadataDrawerEnabled() {

--- a/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-rich-editor/components/NoteFullRichEditor.vue
@@ -33,6 +33,7 @@
         :selected-language="selectedLanguage"
         :translations="translations"
         :is-mobile="isMobile"
+        :is-posting="isPosting"
         :post-key="postKey + enablePostKeys"
         :draft-saving-status="draftSavingStatus"
         :publish-button-text="publishButtonText"
@@ -244,6 +245,10 @@ export default {
     canRedact: {
       type: Boolean,
       default: null
+    },
+    isPosting: {
+      type: Boolean,
+      default: false
     }
   },
   watch: {
@@ -438,7 +443,7 @@ export default {
       this.postAndPublishNote();
     },
     postAndPublishNote(publicationSettings, note, extensionsCallback) {
-      if (this.publicationParams) {
+      if (this.publicationParams && note) {
         this.noteObject = note;
         this.updateData();
       }


### PR DESCRIPTION
Prior to this change, when creating or editing notes containing numerous links, the save operation could take some time to complete without providing any visual indication on the save button.
With this commit, the save button will now display a loading indicator during the save process, giving users clear visibility into the progress and duration of the save operation.