### PR TITLE
fix: Fix duplicated note blank page - EXO-87922

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -242,10 +242,10 @@ export default {
       this.parentPageId = parentNoteId === 'null' ? null : parentNoteId;
       this.spaceId = urlParams.get('spaceId');
       this.spaceGroupId  = urlParams.get('spaceGroupId');
-      this.getTargetSpaceId(this.spaceGroupId);
       this.spaceDisplayName  = urlParams.get('spaceName');
       this.note.parentPageId = this.parentPageId;
     }
+    this.retrieveSpaceInformation(this.spaceGroupId);
     if (urlParams.has('owner')) {
       this.note.wikiOwner = urlParams.get('owner');
     }
@@ -274,7 +274,7 @@ export default {
     this.$root.$on('save-draft', this.autoSave);
   },
   methods: {
-    getTargetSpaceId(groupId) {
+    retrieveSpaceInformation(groupId) {
       if (!groupId) {
         this.canRedact = true;
         return;


### PR DESCRIPTION
Prior to this change, when duplicating a note, a blank page is displayed. This is caused by the fact that "canRedact" prop value is computed from NotesEditorDashboard component then passed to NoteFullRichEditor component only when the url notes-editor url contains "parentNoteId" param which is not the case for duplicated note url like "notes-editor?noteId=XX&translation=&spaceGroupId=XXXXX" After this commit, we will ensure to compute "canRedact" prop value even without "parentNoteId" url param which covers also the duplicated note case.