### PR TITLE
feat: Add remove_note_translation MCP tool - EXO-88371

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/mcp/NoteMcpTool.java
+++ b/notes-service/src/main/java/io/meeds/notes/mcp/NoteMcpTool.java
@@ -168,6 +168,54 @@ public class NoteMcpTool implements McpToolPlugin {
    */
   public List<String> getNoteTranslations(long noteId) throws IllegalAccessException, ObjectNotFoundException {
     getNoteById(noteId); // ACL check: throws if the current user can't view the note
+    return availableTranslationLanguages(noteId);
+  }
+
+  // Removes ONE language's translation of a note, leaving the note's original
+  // content and its other translations intact. Only a user who can edit the note
+  // may remove a translation. To delete the whole note (its original content and
+  // every translation) use delete_note instead.
+  public NoteModel removeNoteTranslation(long noteId, String language) throws IllegalAccessException, ObjectNotFoundException {
+    if (StringUtils.isBlank(language)) {
+      throw new IllegalArgumentException(("No translation language was provided for the note with id %s. Pass the language code "
+          + "of the translation to remove (e.g. 'fr'); use get_note_translations to list the note's existing translations. To "
+          + "delete the whole note (its original content and all translations) use delete_note instead.").formatted(noteId));
+    }
+    Page note = getNoteById(noteId);
+    String username = getCurrentUserName();
+    if (!noteService.canEditNote(note, username)) {
+      throw new IllegalAccessException(NOTE_EDIT_DENIED.formatted(noteId));
+    }
+    String lang = StringUtils.trim(language);
+    // The note's original/default content is stored WITHOUT a language and is
+    // never listed as a translation; removing it would erase the note itself, so
+    // guard against it and point the caller to delete_note.
+    Page defaultNote = getDefaultNote(noteId);
+    String defaultLang = defaultNote == null ? null : defaultNote.getLang();
+    if (StringUtils.isNotBlank(defaultLang) && StringUtils.equalsIgnoreCase(defaultLang, lang)) {
+      throw new IllegalArgumentException(("Language '%s' is the original/default language of the note with id %s, not a "
+          + "translation, so it can't be removed on its own. To delete the whole note use delete_note instead.").formatted(lang,
+                                                                                                                           noteId));
+    }
+    List<String> translations = availableTranslationLanguages(noteId);
+    if (translations.stream().noneMatch(l -> StringUtils.equalsIgnoreCase(l, lang))) {
+      throw new ObjectNotFoundException(("Note with id %s has no translation for language '%s'. Existing translations: %s. Use "
+          + "get_note_translations to list the note's available languages.").formatted(noteId, lang, translations));
+    }
+    try {
+      noteService.deleteVersionsByNoteIdAndLang(Long.valueOf(noteId), lang);
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not remove the note translation: " + e.getMessage());
+    }
+    return getNote(noteId, null);
+  }
+
+  @SneakyThrows
+  private Page getDefaultNote(long noteId) {
+    return noteService.getNoteByIdAndLang(Long.valueOf(noteId), getCurrentUserAclIdentity(), null, null);
+  }
+
+  private List<String> availableTranslationLanguages(long noteId) {
     try {
       return noteService.getPageAvailableTranslationLanguages(noteId, false);
     } catch (Exception e) {

--- a/notes-service/src/main/resources/ai-tool-definitions.json
+++ b/notes-service/src/main/resources/ai-tool-definitions.json
@@ -470,6 +470,34 @@
         "idempotentHint": true,
         "openWorldHint": false
       }
+    },
+    {
+      "name": "remove_note_translation",
+      "title": "Remove a note's translation",
+      "description": "Remove ONE language's translation of a note, leaving the note's original content and its other translations intact. Use get_note_translations to list existing languages. To delete the whole note (its original content and all translations) use delete_note instead.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "note_id": {
+            "type": "integer"
+          },
+          "language": {
+            "type": "string",
+            "description": "The language code of the translation to remove (e.g. 'fr', 'de'). Must be one of the note's existing translations (see get_note_translations); it cannot be the note's original/default language."
+          }
+        },
+        "required": [
+          "note_id",
+          "language"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
     }
   ]
 }

--- a/notes-service/src/test/java/io/meeds/notes/mcp/NoteMcpToolTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/mcp/NoteMcpToolTest.java
@@ -551,6 +551,66 @@ public class NoteMcpToolTest {
   }
 
   @Test
+  public void removeNoteTranslationShouldRemoveExistingTranslation() throws Exception { // NOSONAR
+    Page note = mockPage(String.valueOf(NOTE_ID), "Note");
+
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq("en"))).thenReturn(note);
+    when(noteService.canViewNote(note, USER)).thenReturn(true);
+    when(noteService.canEditNote(note, USER)).thenReturn(true);
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq(null))).thenReturn(note);
+    when(noteService.getPageAvailableTranslationLanguages(NOTE_ID, false)).thenReturn(List.of("en", "fr"));
+
+    NoteModel result = runWithStaticMocks(() -> tool.removeNoteTranslation(NOTE_ID, "fr"));
+
+    assertNotNull(result);
+    assertEquals(NOTE_ID, result.noteId());
+    verify(noteService).deleteVersionsByNoteIdAndLang(NOTE_ID, "fr");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void removeNoteTranslationWhenLanguageBlankShouldThrow() throws Exception { // NOSONAR
+    tool.removeNoteTranslation(NOTE_ID, " ");
+  }
+
+  @Test(expected = IllegalAccessException.class)
+  public void removeNoteTranslationWhenUserCannotEditShouldThrow() throws Exception { // NOSONAR
+    Page note = mockPage(String.valueOf(NOTE_ID), "Note");
+
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq("en"))).thenReturn(note);
+    when(noteService.canViewNote(note, USER)).thenReturn(true);
+    when(noteService.canEditNote(note, USER)).thenReturn(false);
+
+    tool.removeNoteTranslation(NOTE_ID, "fr");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void removeNoteTranslationWhenDefaultLanguageShouldThrow() throws Exception { // NOSONAR
+    Page note = mockPage(String.valueOf(NOTE_ID), "Note");
+    Page defaultNote = mockPage(String.valueOf(NOTE_ID), "Note");
+    lenient().when(defaultNote.getLang()).thenReturn("en");
+
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq("en"))).thenReturn(note);
+    when(noteService.canViewNote(note, USER)).thenReturn(true);
+    when(noteService.canEditNote(note, USER)).thenReturn(true);
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq(null))).thenReturn(defaultNote);
+
+    tool.removeNoteTranslation(NOTE_ID, "en");
+  }
+
+  @Test(expected = ObjectNotFoundException.class)
+  public void removeNoteTranslationWhenTranslationMissingShouldThrow() throws Exception { // NOSONAR
+    Page note = mockPage(String.valueOf(NOTE_ID), "Note");
+
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq("en"))).thenReturn(note);
+    when(noteService.canViewNote(note, USER)).thenReturn(true);
+    when(noteService.canEditNote(note, USER)).thenReturn(true);
+    when(noteService.getNoteByIdAndLang(eq(NOTE_ID), eq(currentIdentity), eq(null), eq(null))).thenReturn(note);
+    when(noteService.getPageAvailableTranslationLanguages(NOTE_ID, false)).thenReturn(List.of("fr"));
+
+    tool.removeNoteTranslation(NOTE_ID, "de");
+  }
+
+  @Test
   public void getNoteInLanguageShouldReadRequestedLanguage() throws Exception { // NOSONAR
     Page note = mockPage(String.valueOf(NOTE_ID), "Note");
 


### PR DESCRIPTION
## What

Adds `remove_note_translation(note_id, language)` to `NoteMcpTool` — the missing **Delete** in the notes translation lifecycle (we already have create/update via `update_note`+language, list via `get_note_translations`, read via `get_note`+language). **Stacked on #1710.**

## How
- Wraps `NoteService.deleteVersionsByNoteIdAndLang(noteId, lang)` — removes one language's versions, leaving the original content + other translations intact.
- `require_approval: true`, `destructiveHint: true`; acts as the user, `canEditNote` permission check.
- **Guards:** blank language → `IllegalArgumentException`; the original/default language (represented as `null`) can't be removed (use `delete_note`) — defensively re-checked against the true null-lang note; a language with no translation → `ObjectNotFoundException` (suggests `get_note_translations`).

## Verified live (Chrome + EVA)
On note 5 ("Cover Repro", with fr + de translations): EVA invoked `remove_note_translation` (with approval) → *"The French translation has been removed; the note retains only its original content."* Server-side confirmed: requesting `?lang=fr` now falls back to the default, **de survived** ("Cover Repro (DE)"), original intact.

## Use case
*"Translate this into French for review… actually, wrong language, remove the French version"* — impossible before without `delete_note` (which destroys the whole note). Completes the translation CRUD and makes `update_note`-with-language safe to promote.

Board: EXO-88371. 31 module tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)