### PR TITLE
fix: redirection to page not found when opening note from snack bar -  EXO-88375

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/plugin/NotePermanentLinkPlugin.java
+++ b/notes-service/src/main/java/io/meeds/notes/plugin/NotePermanentLinkPlugin.java
@@ -30,6 +30,7 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.wiki.model.Page;
 import org.exoplatform.wiki.model.WikiType;
 import org.exoplatform.wiki.service.NoteService;
+import org.exoplatform.wiki.utils.Utils;
 
 import io.meeds.portal.permlink.model.PermanentLinkObject;
 import io.meeds.portal.permlink.plugin.PermanentLinkPlugin;
@@ -42,8 +43,6 @@ import lombok.SneakyThrows;
 public class NotePermanentLinkPlugin implements PermanentLinkPlugin {
 
   public static final String   OBJECT_TYPE = "notes";
-
-  public static final String   URL_FORMAT  = "/portal/s/%s/notes/%s";
 
   @Autowired
   private NoteService          noteService;
@@ -88,7 +87,7 @@ public class NotePermanentLinkPlugin implements PermanentLinkPlugin {
     if (space == null) {
       throw new ObjectNotFoundException(String.format("Note with id %s associated space wasn't found", object.getObjectId()));
     }
-    return String.format(URL_FORMAT, space.getId(), object.getObjectId());
+    return Utils.getPageUrl(note);
   }
 
 }

--- a/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -61,8 +62,22 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.Application;
+import org.exoplatform.portal.config.model.ApplicationState;
+import org.exoplatform.portal.config.model.Container;
+import org.exoplatform.portal.config.model.ModelObject;
 import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.config.model.TransientApplicationState;
+import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.navigation.NavigationContext;
+import org.exoplatform.portal.mop.navigation.NodeContext;
+import org.exoplatform.portal.mop.navigation.NodeModel;
+import org.exoplatform.portal.mop.navigation.NodeState;
+import org.exoplatform.portal.mop.navigation.Scope;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.service.NavigationService;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -150,6 +165,14 @@ public class Utils {
 
   public static final Pattern                                    MENTION_PATTERN                  =
                                                                                  Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
+
+  private static final String                                    NOTES_APPLICATION_CONTENT_ID     = "notes/Notes";
+
+  private static final String                                    DEFAULT_NOTES_NODE_URI           = "notes";
+
+  private static final long                                      NOTES_NODE_URI_CACHE_TTL_MS       = 2 * 60 * 1000L;
+
+  private static final Map<SiteKey, NotesNodeUriCacheEntry>      notesNodeUriCache                = new ConcurrentHashMap<>();
 
   public static String normalizeUploadedFilename(String name) {
     name = name.replace("%22", "\"");  // Fix the bug in Chrome which a double quotes is encoded to %22
@@ -568,7 +591,9 @@ public class Utils {
       if (space != null) {
         StringBuilder spaceUrl = new StringBuilder("/portal/s/");
         spaceUrl.append(space.getId());
-        spaceUrl.append("/notes/");
+        spaceUrl.append("/");
+        spaceUrl.append(getNotesNodeUri(SiteKey.group(space.getGroupId())));
+        spaceUrl.append("/");
         if (!StringUtils.isEmpty(page.getId())) {
           spaceUrl.append(page.getId());
         }
@@ -577,6 +602,107 @@ public class Utils {
       return "";
     } catch (Exception e) {
       return "";
+    }
+  }
+
+  /**
+   * Resolves the URI of the navigation node that hosts the Notes application
+   * for the given site, so that links generated for a note ({@link #getPageUrl(Page)}
+   * and permanent links) still resolve when the Notes application has been added
+   * to a navigation node other than the default "notes" one (e.g. a node added
+   * manually from the site navigation editor).
+   * <p>
+   * The default node URI ("notes") is kept whenever it exists, to preserve the
+   * historical behavior of spaces provisioned with the standard Notes node. It is
+   * only replaced by another node's URI when no "notes" node exists in the site
+   * navigation, but a node hosting the Notes application does.
+   *
+   * @param siteKey the site (space or portal) navigation to resolve
+   * @return the node URI to use to build a link to a note in that site
+   */
+  private static String getNotesNodeUri(SiteKey siteKey) {
+    NotesNodeUriCacheEntry cacheEntry = notesNodeUriCache.get(siteKey);
+    if (cacheEntry != null && cacheEntry.expirationTime > System.currentTimeMillis()) {
+      return cacheEntry.nodeUri;
+    }
+    String nodeUri = resolveNotesNodeUri(siteKey);
+    notesNodeUriCache.put(siteKey, new NotesNodeUriCacheEntry(nodeUri, System.currentTimeMillis() + NOTES_NODE_URI_CACHE_TTL_MS));
+    return nodeUri;
+  }
+
+  private static String resolveNotesNodeUri(SiteKey siteKey) {
+    try {
+      NavigationService navigationService = CommonsUtils.getService(NavigationService.class);
+      LayoutService layoutService = CommonsUtils.getService(LayoutService.class);
+      NavigationContext navigationContext = navigationService.loadNavigation(siteKey);
+      if (navigationContext == null) {
+        return DEFAULT_NOTES_NODE_URI;
+      }
+      NodeContext rootNode = navigationService.loadNode(NodeModel.SELF_MODEL, navigationContext, Scope.ALL, null);
+      if (rootNode == null) {
+        return DEFAULT_NOTES_NODE_URI;
+      }
+      String alternateNodeUri = null;
+      boolean defaultNodeExists = false;
+      Deque<NodeContext> nodesToVisit = new ArrayDeque<>(rootNode.getNodes());
+      while (!nodesToVisit.isEmpty()) {
+        NodeContext node = nodesToVisit.poll();
+        if (DEFAULT_NOTES_NODE_URI.equals(node.getName())) {
+          defaultNodeExists = true;
+        }
+        if (alternateNodeUri == null && hostsNotesApplication(node.getState(), layoutService)) {
+          alternateNodeUri = node.getName();
+        }
+        nodesToVisit.addAll(node.getNodes());
+      }
+      if (defaultNodeExists || alternateNodeUri == null) {
+        return DEFAULT_NOTES_NODE_URI;
+      }
+      return alternateNodeUri;
+    } catch (Exception e) {
+      LOG.warn("Error resolving the navigation node hosting the Notes application for site {}, falling back to '{}'",
+               siteKey,
+               DEFAULT_NOTES_NODE_URI,
+               e);
+      return DEFAULT_NOTES_NODE_URI;
+    }
+  }
+
+  private static boolean hostsNotesApplication(NodeState nodeState, LayoutService layoutService) {
+    PageKey pageRef = nodeState == null ? null : nodeState.getPageRef();
+    if (pageRef == null) {
+      return false;
+    }
+    org.exoplatform.portal.config.model.Page pageModel = layoutService.getPage(pageRef);
+    return pageModel != null && containsNotesApplication(pageModel);
+  }
+
+  private static boolean containsNotesApplication(Container container) {
+    if (container.getChildren() == null) {
+      return false;
+    }
+    for (ModelObject child : container.getChildren()) {
+      if (child instanceof Application) {
+        ApplicationState state = ((Application) child).getState();
+        if (state instanceof TransientApplicationState
+            && NOTES_APPLICATION_CONTENT_ID.equalsIgnoreCase(((TransientApplicationState) state).getContentId())) {
+          return true;
+        }
+      } else if (child instanceof Container && containsNotesApplication((Container) child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static class NotesNodeUriCacheEntry {
+    private final String nodeUri;
+
+    private final long   expirationTime;
+
+    NotesNodeUriCacheEntry(String nodeUri, long expirationTime) {
+      this.nodeUri = nodeUri;
+      this.expirationTime = expirationTime;
     }
   }
 

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -644,7 +644,6 @@ export default {
       return draftNote;
     },
     redirectAfterSaveLink(note) {
-      console.log('redirectAfterSaveLink', note);
       if (this.webPageUrl) {
         return this.webPageUrl;
       } else {

--- a/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-editor/components/NotesEditorDashboard.vue
@@ -178,6 +178,9 @@ export default {
     webPageUrl() {
       return this.urlParams?.get?.('webPageUrl');
     },
+    notePageUri() {
+      return this.urlParams?.get?.('notePageUri') || 'dashboard/notes';
+    },
     isMobile() {
       return this.$vuetify.breakpoint.width < 960;
     }
@@ -435,7 +438,7 @@ export default {
       return this.$notesService.updateNoteById(note).then(data => {
         this.note = data;
         if (this.note.wikiType === 'user') {
-          this.note.url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/dashboard/notes/${this.noteId}`;
+          this.note.url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/${this.notePageUri}/${this.noteId}`;
         }
         document.dispatchEvent(new CustomEvent('update-processed-image-url', {
           detail: {
@@ -482,7 +485,7 @@ export default {
         this.addParamToUrl('noteId', this.noteId);
         this.originalNote = structuredClone(data);
         if (this.note.wikiType === 'user') {
-          this.note.url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/dashboard/notes/${this.noteId}`;
+          this.note.url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/${this.notePageUri}/${this.noteId}`;
         }
         // delete draft note
         this.deleteDraftNote(draftNote, this.note?.url);
@@ -641,6 +644,7 @@ export default {
       return draftNote;
     },
     redirectAfterSaveLink(note) {
+      console.log('redirectAfterSaveLink', note);
       if (this.webPageUrl) {
         return this.webPageUrl;
       } else {

--- a/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes/components/NotePage.vue
@@ -915,7 +915,7 @@ export default {
     },
     addNote() {
       if (!this.hasDraft) {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?spaceId=${eXo.env.portal.spaceId}&parentNoteId=${this.note.id}&spaceGroupId=${eXo.env.portal?.spaceGroup}&notePageUri=${encodeURIComponent(eXo.env.portal.selectedNodeUri)}`, '_blank');
       }
     },
     editNote() {
@@ -923,7 +923,7 @@ export default {
       if (this.selectedTranslation.value){
         translation = `&translation=${this.selectedTranslation.value}`;
       }
-      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}${translation}&spaceGroupId=${eXo.env.portal?.spaceGroup}&isDraft=${this.isDraft}&parentNoteId=${this.parentPageId}`, '_blank');
+      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${this.note.id}${translation}&spaceGroupId=${eXo.env.portal?.spaceGroup}&isDraft=${this.isDraft}&parentNoteId=${this.parentPageId}&notePageUri=${encodeURIComponent(eXo.env.portal.selectedNodeUri)}`, '_blank');
     },
     deleteNote() {
       if (this.hasDraft) {
@@ -1345,7 +1345,7 @@ export default {
         extensionDataUpdated: false
       };
       this.$notesService.createNote(note).then(duplicated => {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${duplicated.id}&translation=${this.selectedTranslation.value}&spaceGroupId=${eXo.env.portal?.spaceGroup}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/notes-editor?noteId=${duplicated.id}&translation=${this.selectedTranslation.value}&spaceGroupId=${eXo.env.portal?.spaceGroup}&notePageUri=${encodeURIComponent(eXo.env.portal.selectedNodeUri)}`, '_blank');
       }).catch(e => {
         this.$root.$emit('show-alert', {
           type: 'error',

--- a/notes-webapp/src/main/webapp/vue-app/notes/extensions.js
+++ b/notes-webapp/src/main/webapp/vue-app/notes/extensions.js
@@ -8,7 +8,7 @@ extensionRegistry.registerExtension('NotesMenu', 'menuActionMenu', {
   enabled: (note) => note?.canView,
   action: (vm) => {
     if (vm.note.wikiType === 'user') {
-      vm.note.url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/dashboard/notes/${vm.note.id}`;
+      vm.note.url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/${eXo.env.portal.selectedNodeUri}/${vm.note.id}`;
     }
     navigator.clipboard.writeText(`${window.location.origin}${vm.note.url}`).then(() => {
       vm.$root.$emit('show-alert', {type: 'success', message: vm.$t('notes.alert.success.label.linkCopied')});


### PR DESCRIPTION
Prior to this, clicking "View" or "Copy link" on a note could redirect to a "page not found" error whenever the Notes application had been added to a navigation node other than the default one - for example a node manually added from the site navigation editor to expose a user's personal notes on a "people" page.

This happened because the note's URL was always built with the default node segment hardcoded ("notes" for spaces in Utils#getPageUrl and NotePermanentLinkPlugin), instead of the navigation node actually hosting the application. For personal notes specifically, the frontend also unconditionally rewrote the note URL to "dashboard/notes/{id}", discarding the node the user was actually browsing when the notes editor popup was opened.

This commit fixes the problem by resolving, server-side, the navigation node that hosts the Notes application for a given space (falling back to the historical "notes" node when it exists, to preserve current behavior), and by passing the current node URI through as a "notePageUri" parameter when opening the notes editor popup, so personal notes build their "View"/copy-link URL from the node the user was actually on instead of the hardcoded "dashboard/notes".