### PR TITLE
feat: Display pages carrying a content block in the unified search - EXO-88571 - eXIP7.3.0.13

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/listener/NoteContentIndexingListener.java
+++ b/notes-service/src/main/java/io/meeds/notes/listener/NoteContentIndexingListener.java
@@ -1,0 +1,91 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.notes.listener;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.wiki.model.Page;
+
+import org.exoplatform.wiki.jpa.search.PageContentIndexingServiceConnector;
+
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.service.CMSService;
+
+/**
+ * Reacts to Notes' {@code note.posted} / {@code note.updated} events to
+ * re-index the portal Page carrying this note as a Single Note View content
+ * block, so the "page" search index stays in sync when the note's content
+ * (not the page layout) is what changed.
+ * <p>
+ * A note is a Single Note View's content when a {@code notePage}
+ * {@link CMSSetting} exists whose name equals the note's own name (that
+ * invariant is guaranteed by {@code NotePageViewService#persistNotePage},
+ * which always creates such a note as {@code new Page(name, name)}).
+ */
+public class NoteContentIndexingListener extends Listener<String, Page> {
+
+  private static final String CMS_CONTENT_TYPE = "notePage";
+
+  private final IndexingService indexingService;
+
+  public NoteContentIndexingListener(IndexingService indexingService) {
+    this.indexingService = indexingService;
+  }
+
+  @Override
+  public void onEvent(Event<String, Page> event) throws Exception {
+    Page note = event.getData();
+    if (note == null || StringUtils.isBlank(note.getName())) {
+      return;
+    }
+    CMSSetting setting = findNotePageSetting(note.getName());
+    if (setting == null) {
+      // Not a note bound to a page as a Single Note View content block
+      return;
+    }
+    org.exoplatform.portal.config.model.Page page = getLayoutService().getPage(PageKey.parse(setting.getPageReference()));
+    if (page == null) {
+      return;
+    }
+    indexingService.reindex(PageContentIndexingServiceConnector.TYPE, page.getStorageId());
+  }
+
+  private CMSSetting findNotePageSetting(String noteName) {
+    return getCmsService().getSettingsByType(CMS_CONTENT_TYPE)
+                          .stream()
+                          .filter(setting -> StringUtils.equals(setting.getName(), noteName))
+                          .findFirst()
+                          .orElse(null);
+  }
+
+  private CMSService getCmsService() {
+    return CommonsUtils.getService(CMSService.class);
+  }
+
+  private LayoutService getLayoutService() {
+    return CommonsUtils.getService(LayoutService.class);
+  }
+
+}

--- a/notes-service/src/main/java/io/meeds/notes/listener/PageContentBlockIndexingListener.java
+++ b/notes-service/src/main/java/io/meeds/notes/listener/PageContentBlockIndexingListener.java
@@ -1,0 +1,84 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.notes.listener;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+
+import org.exoplatform.wiki.jpa.search.PageContentIndexingServiceConnector;
+
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.service.CMSService;
+
+/**
+ * Reacts to Layout's {@code layout.page.updated} / {@code layout.page.permissions.updated}
+ * events (fired by {@code io.meeds.layout.service.PageLayoutService}) to keep the
+ * "page" search index in sync with whether a page currently carries a Notes
+ * "notePage" content block.
+ */
+public class PageContentBlockIndexingListener extends Listener<String, String> {
+
+  private static final String CMS_CONTENT_TYPE = "notePage";
+
+  private final IndexingService indexingService;
+
+  public PageContentBlockIndexingListener(IndexingService indexingService) {
+    this.indexingService = indexingService;
+  }
+
+  @Override
+  public void onEvent(Event<String, String> event) throws Exception {
+    String pageRef = event.getData();
+    if (StringUtils.isBlank(pageRef)) {
+      return;
+    }
+    org.exoplatform.portal.config.model.Page page = getLayoutService().getPage(PageKey.parse(pageRef));
+    if (page == null) {
+      return;
+    }
+    String storageId = page.getStorageId();
+    if (hasNotePageContentBlock(pageRef)) {
+      indexingService.index(PageContentIndexingServiceConnector.TYPE, storageId);
+    } else {
+      indexingService.unindex(PageContentIndexingServiceConnector.TYPE, storageId);
+    }
+  }
+
+  private boolean hasNotePageContentBlock(String pageRef) {
+    return getCmsService().getSettingsByType(CMS_CONTENT_TYPE)
+                          .stream()
+                          .map(CMSSetting::getPageReference)
+                          .anyMatch(pageReference -> StringUtils.equals(pageReference, pageRef));
+  }
+
+  private CMSService getCmsService() {
+    return CommonsUtils.getService(CMSService.class);
+  }
+
+  private LayoutService getLayoutService() {
+    return CommonsUtils.getService(LayoutService.class);
+  }
+
+}

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageContentIndexingServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageContentIndexingServiceConnector.java
@@ -1,0 +1,224 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.wiki.jpa.search;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.search.domain.Document;
+import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.ExpressionUtil;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.resources.LocaleConfigService;
+import org.exoplatform.services.resources.LocaleContextInfo;
+import org.exoplatform.services.resources.ResourceBundleManager;
+import org.exoplatform.wiki.model.Page;
+import org.exoplatform.wiki.utils.Utils;
+
+import io.meeds.notes.service.NotePageViewService;
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.service.CMSService;
+
+/**
+ * Indexes a portal Page as soon as it carries a "content block" (today: the
+ * Notes Single Note View portlet, bound through a {@code notePage}
+ * {@link CMSSetting}). What is indexed is the content of the block (title,
+ * author, date, plain-text content), the Page only provides the
+ * "page name - site name" / link context.
+ * <p>
+ * The document id is the page's numeric storage id (not its
+ * {@link PageKey#format()}, which can exceed the 50-character limit of the
+ * {@code ES_INDEXING_QUEUE.ENTITY_ID} column) — it is also stable across
+ * page/site renames, unlike the formatted key.
+ */
+public class PageContentIndexingServiceConnector extends ElasticIndexingServiceConnector {
+
+  public static final String TYPE                   = "page";
+
+  private static final String CMS_CONTENT_TYPE       = "notePage";
+
+  private static final Log    LOGGER                 = ExoLogger.getExoLogger(PageContentIndexingServiceConnector.class);
+
+  public PageContentIndexingServiceConnector(InitParams initParams) {
+    super(initParams);
+  }
+
+  @Override
+  public String getMapping() {
+    return "{"
+        + "  \"properties\" : {"
+        + "    \"title\" : {\"type\" : \"text\", \"index_options\": \"offsets\","
+        + "      \"fields\": {\"raw\": {\"type\": \"keyword\"}}},"
+        + "    \"siteName\" : {\"type\" : \"keyword\"},"
+        + "    \"author\" : {\"type\" : \"keyword\"},"
+        + "    \"date\" : {\"type\" : \"date\", \"format\": \"epoch_millis\"},"
+        + "    \"permissions\" : {\"type\" : \"keyword\"},"
+        + "    \"content\" : {\"type\" : \"text\", \"store\": true, \"term_vector\": \"with_positions_offsets\"}"
+        + "  }"
+        + "}";
+  }
+
+  @Override
+  public String getConnectorName() {
+    return TYPE;
+  }
+
+  @Override
+  public List<String> getAllIds(int offset, int limit) {
+    List<CMSSetting> settings = getCmsService().getSettingsByType(CMS_CONTENT_TYPE);
+    return settings.stream()
+                   .map(CMSSetting::getPageReference)
+                   .filter(StringUtils::isNotBlank)
+                   .distinct()
+                   .map(this::resolveStorageId)
+                   .filter(StringUtils::isNotBlank)
+                   .skip(offset)
+                   .limit(limit)
+                   .toList();
+  }
+
+  @Override
+  public Document create(String id) {
+    if (StringUtils.isBlank(id)) {
+      throw new IllegalArgumentException("Id is null");
+    }
+    try {
+      // Read the raw (unrestricted) layout data: indexing must see the page
+      // regardless of any user's view permission, the resulting permissions
+      // are stored on the Document itself for the search engine to filter on.
+      org.exoplatform.portal.config.model.Page page = getLayoutService().getPage(parseStorageId(id));
+      if (page == null) {
+        LOGGER.warn("Page with storage id {} wasn't found, thus it can't be indexed", id);
+        return null;
+      }
+      PageKey pageKey = page.getPageKey();
+      CMSSetting setting = findNotePageSetting(pageKey.format());
+      if (setting == null) {
+        LOGGER.warn("Page {} doesn't carry any 'notePage' content block anymore, thus it can't be indexed", pageKey);
+        return null;
+      }
+      Page note = getNotePageViewService().getNotePages(setting.getName()).get("");
+      if (note == null) {
+        LOGGER.warn("No note found for setting {} referenced by page {}, thus it can't be indexed", setting.getName(), pageKey);
+        return null;
+      }
+
+      Map<String, String> fields = new HashMap<>();
+      fields.put("title", page.getTitle());
+      fields.put("siteName", getSiteDisplayName(pageKey));
+      fields.put("author", note.getAuthor());
+      fields.put("date", String.valueOf(note.getUpdatedDate() == null ? note.getCreatedDate().getTime()
+                                                                       : note.getUpdatedDate().getTime()));
+      fields.put("content", Utils.html2text(note.getContent()));
+
+      Document document = new Document();
+      document.setId(id);
+      document.setLastUpdatedDate(note.getUpdatedDate());
+      document.setPermissions(page.getAccessPermissions() == null ? new HashSet<>()
+                                                                    : new HashSet<>(Arrays.asList(page.getAccessPermissions())));
+      document.setFields(fields);
+      return document;
+    } catch (Exception e) {
+      LOGGER.warn("Cannot index page with id {}", id, e);
+      return null;
+    }
+  }
+
+  @Override
+  public Document update(String id) {
+    return create(id);
+  }
+
+  private long parseStorageId(String storageId) {
+    // PageStorageImpl builds page storage ids as "page_" + <numeric DB id>
+    return Long.parseLong(StringUtils.removeStart(storageId, "page_"));
+  }
+
+  private String resolveStorageId(String pageReference) {
+    try {
+      org.exoplatform.portal.config.model.Page page = getLayoutService().getPage(PageKey.parse(pageReference));
+      return page == null ? null : page.getStorageId();
+    } catch (Exception e) {
+      LOGGER.debug("Cannot resolve storage id of page {}", pageReference, e);
+      return null;
+    }
+  }
+
+  private CMSSetting findNotePageSetting(String pageReference) {
+    return getCmsService().getSettingsByType(CMS_CONTENT_TYPE)
+                          .stream()
+                          .filter(setting -> StringUtils.equals(setting.getPageReference(), pageReference))
+                          .findFirst()
+                          .orElse(null);
+  }
+
+  private String getSiteDisplayName(PageKey pageKey) {
+    PortalConfig site = getLayoutService().getPortalConfig(pageKey.getSite());
+    String label = site == null ? null : site.getLabel();
+    if (StringUtils.isBlank(label)) {
+      return pageKey.getSite().getName();
+    }
+    if (ExpressionUtil.isResourceBindingExpression(label)) {
+      String resolved = resolveLabelExpression(pageKey, label);
+      return StringUtils.isNotBlank(resolved) ? resolved : pageKey.getSite().getName();
+    }
+    return label;
+  }
+
+  private String resolveLabelExpression(PageKey pageKey, String label) {
+    try {
+      LocaleConfigService localeConfigService = CommonsUtils.getService(LocaleConfigService.class);
+      Locale locale = localeConfigService.getDefaultLocaleConfig().getLocale();
+      ResourceBundle bundle = CommonsUtils.getService(ResourceBundleManager.class)
+                                          .getNavigationResourceBundle(LocaleContextInfo.getLocaleAsString(locale),
+                                                                       pageKey.getSite().getTypeName(),
+                                                                       pageKey.getSite().getName());
+      return bundle == null ? null : ExpressionUtil.getExpressionValue(bundle, label);
+    } catch (Exception e) {
+      LOGGER.debug("Cannot resolve site label expression {} for site {}", label, pageKey.getSite(), e);
+      return null;
+    }
+  }
+
+  private CMSService getCmsService() {
+    return CommonsUtils.getService(CMSService.class);
+  }
+
+  private NotePageViewService getNotePageViewService() {
+    return CommonsUtils.getService(NotePageViewService.class);
+  }
+
+  private LayoutService getLayoutService() {
+    return CommonsUtils.getService(LayoutService.class);
+  }
+
+}

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageContentIndexingServiceConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageContentIndexingServiceConnector.java
@@ -1,0 +1,196 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.wiki.jpa.search;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.search.domain.Document;
+import org.exoplatform.commons.search.index.impl.ElasticIndexingServiceConnector;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.wiki.model.Page;
+import org.exoplatform.wiki.utils.Utils;
+
+import io.meeds.notes.service.NotePageViewService;
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.service.CMSService;
+
+/**
+ * Indexes a portal Page as soon as it carries a "content block" (today: the
+ * Notes Single Note View portlet, bound through a {@code notePage}
+ * {@link CMSSetting}). What is indexed is the content of the block (title,
+ * author, date, plain-text content), the Page only provides the
+ * "page name - site name" / link context.
+ * <p>
+ * The document id is the page's numeric storage id (not its
+ * {@link PageKey#format()}, which can exceed the 50-character limit of the
+ * {@code ES_INDEXING_QUEUE.ENTITY_ID} column) — it is also stable across
+ * page/site renames, unlike the formatted key.
+ */
+public class PageContentIndexingServiceConnector extends ElasticIndexingServiceConnector {
+
+  public static final String TYPE                   = "page";
+
+  private static final String CMS_CONTENT_TYPE       = "notePage";
+
+  private static final Log    LOGGER                 = ExoLogger.getExoLogger(PageContentIndexingServiceConnector.class);
+
+  public PageContentIndexingServiceConnector(InitParams initParams) {
+    super(initParams);
+  }
+
+  @Override
+  public String getMapping() {
+    return "{"
+        + "  \"properties\" : {"
+        + "    \"title\" : {\"type\" : \"text\", \"index_options\": \"offsets\","
+        + "      \"fields\": {\"raw\": {\"type\": \"keyword\"}}},"
+        + "    \"siteName\" : {\"type\" : \"keyword\"},"
+        + "    \"author\" : {\"type\" : \"keyword\"},"
+        + "    \"date\" : {\"type\" : \"date\", \"format\": \"epoch_millis\"},"
+        + "    \"permissions\" : {\"type\" : \"keyword\"},"
+        + "    \"content\" : {\"type\" : \"text\", \"store\": true, \"term_vector\": \"with_positions_offsets\"}"
+        + "  }"
+        + "}";
+  }
+
+  @Override
+  public String getConnectorName() {
+    return TYPE;
+  }
+
+  @Override
+  public List<String> getAllIds(int offset, int limit) {
+    List<CMSSetting> settings = getCmsService().getSettingsByType(CMS_CONTENT_TYPE);
+    return settings.stream()
+                   .map(CMSSetting::getPageReference)
+                   .filter(StringUtils::isNotBlank)
+                   .distinct()
+                   .map(this::resolveStorageId)
+                   .filter(StringUtils::isNotBlank)
+                   .skip(offset)
+                   .limit(limit)
+                   .toList();
+  }
+
+  @Override
+  public Document create(String id) {
+    if (StringUtils.isBlank(id)) {
+      throw new IllegalArgumentException("Id is null");
+    }
+    try {
+      // Read the raw (unrestricted) layout data: indexing must see the page
+      // regardless of any user's view permission, the resulting permissions
+      // are stored on the Document itself for the search engine to filter on.
+      org.exoplatform.portal.config.model.Page page = getLayoutService().getPage(parseStorageId(id));
+      if (page == null) {
+        LOGGER.warn("Page with storage id {} wasn't found, thus it can't be indexed", id);
+        return null;
+      }
+      PageKey pageKey = page.getPageKey();
+      CMSSetting setting = findNotePageSetting(pageKey.format());
+      if (setting == null) {
+        LOGGER.warn("Page {} doesn't carry any 'notePage' content block anymore, thus it can't be indexed", pageKey);
+        return null;
+      }
+      Page note = getNotePageViewService().getNotePages(setting.getName()).get("");
+      if (note == null) {
+        LOGGER.warn("No note found for setting {} referenced by page {}, thus it can't be indexed", setting.getName(), pageKey);
+        return null;
+      }
+
+      Map<String, String> fields = new HashMap<>();
+      fields.put("title", page.getTitle());
+      fields.put("siteName", getSiteDisplayName(pageKey));
+      fields.put("author", note.getAuthor());
+      fields.put("date", String.valueOf(note.getUpdatedDate() == null ? note.getCreatedDate().getTime()
+                                                                       : note.getUpdatedDate().getTime()));
+      fields.put("content", Utils.html2text(note.getContent()));
+
+      Document document = new Document();
+      document.setId(id);
+      document.setLastUpdatedDate(note.getUpdatedDate());
+      document.setPermissions(page.getAccessPermissions() == null ? new HashSet<>()
+                                                                    : new HashSet<>(Arrays.asList(page.getAccessPermissions())));
+      document.setFields(fields);
+      return document;
+    } catch (Exception e) {
+      LOGGER.warn("Cannot index page with id {}", id, e);
+      return null;
+    }
+  }
+
+  @Override
+  public Document update(String id) {
+    return create(id);
+  }
+
+  private long parseStorageId(String storageId) {
+    // PageStorageImpl builds page storage ids as "page_" + <numeric DB id>
+    return Long.parseLong(StringUtils.removeStart(storageId, "page_"));
+  }
+
+  private String resolveStorageId(String pageReference) {
+    try {
+      org.exoplatform.portal.config.model.Page page = getLayoutService().getPage(PageKey.parse(pageReference));
+      return page == null ? null : page.getStorageId();
+    } catch (Exception e) {
+      LOGGER.debug("Cannot resolve storage id of page {}", pageReference, e);
+      return null;
+    }
+  }
+
+  private CMSSetting findNotePageSetting(String pageReference) {
+    return getCmsService().getSettingsByType(CMS_CONTENT_TYPE)
+                          .stream()
+                          .filter(setting -> StringUtils.equals(setting.getPageReference(), pageReference))
+                          .findFirst()
+                          .orElse(null);
+  }
+
+  private String getSiteDisplayName(PageKey pageKey) {
+    PortalConfig site = getLayoutService().getPortalConfig(pageKey.getSite());
+    String label = site == null ? null : site.getLabel();
+    return StringUtils.isNotBlank(label) ? label : pageKey.getSite().getName();
+  }
+
+  private CMSService getCmsService() {
+    return CommonsUtils.getService(CMSService.class);
+  }
+
+  private NotePageViewService getNotePageViewService() {
+    return CommonsUtils.getService(NotePageViewService.class);
+  }
+
+  private LayoutService getLayoutService() {
+    return CommonsUtils.getService(LayoutService.class);
+  }
+
+}

--- a/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageSearchConnector.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/jpa/search/PageSearchConnector.java
@@ -1,0 +1,258 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.wiki.jpa.search;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import org.exoplatform.commons.search.es.ElasticSearchException;
+import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.IOUtil;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.PropertiesParam;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.navigation.NodeContext;
+import org.exoplatform.portal.mop.navigation.NodeData;
+import org.exoplatform.portal.mop.navigation.NodeState;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.service.NavigationService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.services.security.MembershipEntry;
+
+import io.meeds.layout.service.NavigationLayoutService;
+
+import org.exoplatform.wiki.service.search.PageSearchResult;
+
+/**
+ * Query-time connector for the "page" unified-search content type: queries
+ * the {@code page_content_alias} ES index (populated by
+ * {@link PageContentIndexingServiceConnector}) and resolves each hit's
+ * clickable URL (first navigation node found pointing to the page, if any).
+ */
+public class PageSearchConnector {
+
+  private static final Log             LOGGER                   = ExoLogger.getExoLogger(PageSearchConnector.class);
+
+  private static final String          SEARCH_QUERY_FILE_PATH_PARAM = "query.file.path";
+
+  private static final String          PAGE_STORAGE_ID_PREFIX   = "page_";
+
+  private final ConfigurationManager   configurationManager;
+
+  private final ElasticSearchingClient client;
+
+  private final String                 index;
+
+  private String                       searchQueryFilePath;
+
+  private String                       searchQuery;
+
+  public PageSearchConnector(ConfigurationManager configurationManager,
+                             ElasticSearchingClient client,
+                             InitParams initParams) {
+    this.configurationManager = configurationManager;
+    this.client = client;
+
+    PropertiesParam param = initParams.getPropertiesParam("constructor.params");
+    this.index = param.getProperty("index");
+    if (initParams.containsKey(SEARCH_QUERY_FILE_PATH_PARAM)) {
+      this.searchQueryFilePath = initParams.getValueParam(SEARCH_QUERY_FILE_PATH_PARAM).getValue();
+      try {
+        retrieveSearchQuery();
+      } catch (Exception e) {
+        LOGGER.error("Can't read elasticsearch search query from path {}", searchQueryFilePath, e);
+      }
+    }
+  }
+
+  public List<PageSearchResult> search(String keyword, int offset, int limit) {
+    if (StringUtils.isBlank(keyword)) {
+      return List.of();
+    }
+    String esQuery = retrieveSearchQuery().replace("@keyword@", StringUtils.replace(keyword, "\"", "\\\""))
+                                          .replace("@offset@", String.valueOf(Math.max(offset, 0)))
+                                          .replace("@limit@", String.valueOf(Math.max(limit, 1)))
+                                          .replace("@permissions_filter@", buildPermissionsFilter());
+    String jsonResponse = client.sendRequest(esQuery, index);
+    List<PageSearchResult> results = parseResults(jsonResponse);
+    results.forEach(result -> result.setUrl(resolveUrl(result.getId())));
+    return results;
+  }
+
+  private String buildPermissionsFilter() {
+    Identity identity = ConversationState.getCurrent().getIdentity();
+    StringBuilder filter = new StringBuilder();
+    filter.append("{\"term\":{\"permissions\":\"").append(identity.getUserId()).append("\"}},")
+          .append("{\"term\":{\"permissions\":\"").append(IdentityConstants.ANY).append("\"}},")
+          .append("{\"term\":{\"permissions\":\"").append(UserACL.EVERYONE).append("\"}}");
+    Set<String> memberships = new HashSet<>();
+    if (identity.getMemberships() != null) {
+      for (MembershipEntry entry : identity.getMemberships()) {
+        String value = entry.toString();
+        if (MembershipEntry.ANY_TYPE.equals(entry.getMembershipType())) {
+          value = value.replace("*", ".*");
+        }
+        memberships.add(value);
+      }
+    }
+    if (!memberships.isEmpty()) {
+      filter.append(",{\"regexp\":{\"permissions\":\"")
+            .append(StringUtils.join(memberships, "|"))
+            .append("\"}}");
+    }
+    return filter.toString();
+  }
+
+  @SuppressWarnings("rawtypes")
+  private List<PageSearchResult> parseResults(String jsonResponse) {
+    List<PageSearchResult> results = new ArrayList<>();
+    JSONParser parser = new JSONParser();
+    Map json;
+    try {
+      json = (Map) parser.parse(jsonResponse);
+    } catch (ParseException e) {
+      throw new ElasticSearchException("Unable to parse JSON response", e);
+    }
+    JSONObject hitsWrapper = (JSONObject) json.get("hits");
+    if (hitsWrapper == null) {
+      return results;
+    }
+    JSONArray hits = (JSONArray) hitsWrapper.get("hits");
+    if (hits == null) {
+      return results;
+    }
+    for (Object hitObj : hits) {
+      try {
+        JSONObject hit = (JSONObject) hitObj;
+        JSONObject source = (JSONObject) hit.get("_source");
+        PageSearchResult result = new PageSearchResult();
+        result.setId((String) hit.get("_id"));
+        result.setTitle((String) source.get("title"));
+        result.setSiteName((String) source.get("siteName"));
+        result.setAuthor((String) source.get("author"));
+        String date = (String) source.get("date");
+        result.setDate(StringUtils.isBlank(date) ? 0 : Long.parseLong(date));
+        result.setExcerpt(extractExcerpt(hit, source));
+        results.add(result);
+      } catch (Exception e) {
+        LOGGER.warn("Error processing page search result item, ignore it from results", e);
+      }
+    }
+    return results;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private String extractExcerpt(JSONObject hit, JSONObject source) {
+    JSONObject highlight = (JSONObject) hit.get("highlight");
+    if (highlight != null) {
+      JSONArray contentFragments = (JSONArray) highlight.get("content");
+      if (contentFragments != null && !contentFragments.isEmpty()) {
+        return StringUtils.join(contentFragments, " ... ");
+      }
+    }
+    String content = (String) source.get("content");
+    return StringUtils.isBlank(content) ? "" : StringUtils.abbreviate(content, 150);
+  }
+
+  /**
+   * Resolves the portal URL of the page identified by its storage id, using
+   * the first navigation node found pointing to it. Returns {@code null}
+   * when the page can't be resolved or no navigation node points to it.
+   */
+  private String resolveUrl(String storageId) {
+    try {
+      long numericId = Long.parseLong(StringUtils.removeStart(storageId, PAGE_STORAGE_ID_PREFIX));
+      Page page = getLayoutService().getPage(numericId);
+      if (page == null) {
+        return null;
+      }
+      PageKey pageKey = page.getPageKey();
+      NodeContext<NodeContext<Object>> root = getNavigationService().loadNode(pageKey.getSite());
+      NodeData node = findNodeByPage(root, pageKey);
+      // getNodeUri() returns the path relative to the portal context (e.g.
+      // used as `/portal${uri}` by PagePreviewButton.vue in Layout) - the
+      // "/portal" prefix must be added here, it is not part of the URI itself.
+      return node == null ? null : "/portal" + getNavigationLayoutService().getNodeUri(node);
+    } catch (Exception e) {
+      LOGGER.debug("Cannot resolve a navigation node/url for page with storage id {}", storageId, e);
+      return null;
+    }
+  }
+
+  private NodeData findNodeByPage(NodeContext<NodeContext<Object>> node, PageKey pageKey) {
+    if (node == null) {
+      return null;
+    }
+    NodeState state = node.getState();
+    if (state != null && pageKey.equals(state.getPageRef())) {
+      return node.getData();
+    }
+    int count = node.getNodeCount();
+    for (int i = 0; i < count; i++) {
+      NodeData found = findNodeByPage(node.get(i), pageKey);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private String retrieveSearchQuery() {
+    if (StringUtils.isBlank(this.searchQuery)) {
+      try {
+        InputStream queryFileIS = this.configurationManager.getInputStream(searchQueryFilePath);
+        this.searchQuery = IOUtil.getStreamContentAsString(queryFileIS);
+      } catch (Exception e) {
+        throw new IllegalStateException("Error retrieving search query from file: " + searchQueryFilePath, e);
+      }
+    }
+    return this.searchQuery;
+  }
+
+  private LayoutService getLayoutService() {
+    return CommonsUtils.getService(LayoutService.class);
+  }
+
+  private NavigationService getNavigationService() {
+    return CommonsUtils.getService(NavigationService.class);
+  }
+
+  private NavigationLayoutService getNavigationLayoutService() {
+    return CommonsUtils.getService(NavigationLayoutService.class);
+  }
+
+}

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/rest/NotesRestService.java
@@ -92,6 +92,7 @@ import org.exoplatform.wiki.model.PageHistory;
 import org.exoplatform.wiki.model.PageVersion;
 import org.exoplatform.wiki.model.Wiki;
 import org.exoplatform.wiki.model.WikiType;
+import org.exoplatform.wiki.jpa.search.PageSearchConnector;
 import org.exoplatform.wiki.resolver.TitleResolver;
 import org.exoplatform.wiki.service.NoteService;
 import org.exoplatform.wiki.service.NotesExportService;
@@ -101,6 +102,7 @@ import org.exoplatform.wiki.service.WikiService;
 import org.exoplatform.wiki.service.impl.BeanToJsons;
 import org.exoplatform.wiki.service.search.SearchResult;
 import org.exoplatform.wiki.service.search.NoteSearchResult;
+import org.exoplatform.wiki.service.search.PageSearchResult;
 import org.exoplatform.wiki.service.search.WikiSearchData;
 import org.exoplatform.wiki.tree.JsonNodeData;
 import org.exoplatform.wiki.tree.PageTreeNode;
@@ -1354,6 +1356,31 @@ public class NotesRestService implements ResourceContainer {
       return Response.ok(new BeanToJsons(noteSearchResults), MediaType.APPLICATION_JSON).cacheControl(cc).build();
     } catch (Exception e) {
       LOG.error("Error when search notes", e);
+      return Response.serverError().build();
+    }
+  }
+
+  /**
+   * Unified-search endpoint for pages carrying a content block (Single Note
+   * View), used by the "page" search connector.
+   */
+  @GET
+  @Path("pagesearch/")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  public Response searchPages(@Context UriInfo uriInfo,
+                              @QueryParam("keyword")
+                              String keyword,
+                              @QueryParam("limit")
+                              int limit,
+                              @QueryParam("offset")
+                              int offset) {
+    limit = limit > 0 ? limit : RestUtils.getLimit(uriInfo);
+    try {
+      List<PageSearchResult> results = CommonsUtils.getService(PageSearchConnector.class).search(keyword, offset, limit);
+      return Response.ok(new BeanToJsons(results), MediaType.APPLICATION_JSON).cacheControl(cc).build();
+    } catch (Exception e) {
+      LOG.error("Error when searching pages", e);
       return Response.serverError().build();
     }
   }

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/search/PageSearchResult.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/search/PageSearchResult.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.wiki.service.search;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A unified-search result for a portal Page carrying a content block
+ * (Single Note View). The id is the page's storage id (e.g.
+ * {@code page_139}), matching what {@code PageContentIndexingServiceConnector}
+ * indexed.
+ */
+@Data
+@NoArgsConstructor
+public class PageSearchResult {
+
+  private String id;
+
+  private String title;
+
+  private String siteName;
+
+  private String excerpt;
+
+  private String author;
+
+  private long   date;
+
+  private String url;
+
+}

--- a/notes-service/src/main/resources/conf/portal/configuration.xml
+++ b/notes-service/src/main/resources/conf/portal/configuration.xml
@@ -147,6 +147,20 @@
     </init-params>
   </component>
 
+  <component>
+    <type>org.exoplatform.wiki.jpa.search.PageSearchConnector</type>
+    <init-params>
+      <value-param>
+        <name>query.file.path</name>
+        <value>${exo.notes.page.es.query.path:jar:/page-search-query.json}</value>
+      </value-param>
+      <properties-param>
+        <name>constructor.params</name>
+        <property name="index" value="page_content_alias"/>
+      </properties-param>
+    </init-params>
+  </component>
+
   <external-component-plugins>
     <target-component>org.exoplatform.wiki.service.WikiService</target-component>
     <component-plugin profiles="all">

--- a/notes-service/src/main/resources/conf/portal/configuration.xml
+++ b/notes-service/src/main/resources/conf/portal/configuration.xml
@@ -321,6 +321,19 @@
         </properties-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>PageContentIndexingConnector</name>
+      <set-method>addConnector</set-method>
+      <type>org.exoplatform.wiki.jpa.search.PageContentIndexingServiceConnector</type>
+      <description>Page Content Block ElasticSearch Indexing Connector</description>
+      <init-params>
+        <properties-param>
+          <name>constructor.params</name>
+          <property name="index_alias" value="page_content_alias"/>
+          <property name="index_current" value="page_content"/>
+        </properties-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>
@@ -379,6 +392,26 @@
       <name>social.metadataItem.updated</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.wiki.service.listener.MetadataItemModified</type>
+    </component-plugin>
+    <component-plugin>
+      <name>layout.page.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.notes.listener.PageContentBlockIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>layout.page.permissions.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.notes.listener.PageContentBlockIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>note.posted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.notes.listener.NoteContentIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>note.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.notes.listener.NoteContentIndexingListener</type>
     </component-plugin>
   </external-component-plugins>
 

--- a/notes-service/src/main/resources/page-search-query.json
+++ b/notes-service/src/main/resources/page-search-query.json
@@ -1,0 +1,35 @@
+{
+  "from": "@offset@",
+  "size": "@limit@",
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "multi_match": {
+            "query": "@keyword@",
+            "fields": ["title^2", "content"],
+            "fuzziness": "AUTO"
+          }
+        }
+      ],
+      "filter": {
+        "bool": {
+          "should": [
+            @permissions_filter@
+          ]
+        }
+      }
+    }
+  },
+  "highlight": {
+    "number_of_fragments": 2,
+    "fragment_size": 150,
+    "no_match_size": 0,
+    "fields": {
+      "content": {
+        "pre_tags": ["<span class='searchMatchExcerpt'>"],
+        "post_tags": ["</span>"]
+      }
+    }
+  }
+}

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
@@ -103,6 +103,7 @@ UIWikiSearchBox.label.Search=Search
 UIWikiSearchBox.label.SearchFor=Search for
 UIWikiSearchBox.label.Loading=Loading...
 search.connector.label.notes=Notes
+search.connector.label.page=Pages
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
@@ -103,6 +103,7 @@ UIWikiSearchBox.label.Search=Recherche
 UIWikiSearchBox.label.SearchFor=Recherche
 UIWikiSearchBox.label.Loading=Chargement...
 search.connector.label.notes=Notes
+search.connector.label.page=Pages
 #############################################################################
 #UIWikiAdvanceSearchForm
 #############################################################################

--- a/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/search-configuration.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/conf/wiki/search-configuration.xml
@@ -74,6 +74,53 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>PageSearchConnector</name>
+      <set-method>addConnector</set-method>
+      <type>org.exoplatform.social.core.search.SearchConnectorPlugin</type>
+      <description>Page content block Search connector</description>
+      <init-params>
+        <object-param>
+          <name>PageSearchConnector</name>
+          <description>Search connector for pages carrying a content block</description>
+          <object type="org.exoplatform.social.core.search.SearchConnector">
+            <field name="name">
+              <string>page</string>
+            </field>
+            <field name="contentType">
+              <string>page</string>
+            </field>
+            <field name="uri">
+              <string><![CDATA[/portal/rest/notes/pagesearch?limit={limit}&keyword={keyword}]]></string>
+            </field>
+            <field name="enabled">
+              <boolean>${exo.search.page.enabled:true}</boolean>
+            </field>
+            <field name="jsModule">
+              <string>SHARED/pageSearchCard</string>
+            </field>
+            <field name="i18nBundle">
+              <string>locale.portlet.wiki.WikiPortlet</string>
+            </field>
+            <field name="uiComponent">
+              <string>page-search-card</string>
+            </field>
+            <field name="icon">
+              <string>fas fa-file-alt</string>
+            </field>
+            <field name="favoritesEnabled">
+              <boolean>false</boolean>
+            </field>
+            <field name="tagsEnabled">
+              <boolean>false</boolean>
+            </field>
+            <field name="spaceFilterEnabled">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>

--- a/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/notes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -365,6 +365,33 @@
   </module>
 
   <module>
+    <name>pageSearchCard</name>
+    <script>
+      <minify>false</minify>
+      <path>/javascript/pageSearchCard.bundle.js</path>
+    </script>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>jquery</module>
+      <as>$</as>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
+  <module>
     <name>vueCustomElement</name>
     <script>
       <path>/javascript/lib/vue-custom-element.min.js</path>

--- a/notes-webapp/src/main/webapp/vue-app/pageSearch/components/PageSearchCard.vue
+++ b/notes-webapp/src/main/webapp/vue-app/pageSearch/components/PageSearchCard.vue
@@ -1,0 +1,87 @@
+<template>
+  <v-hover v-slot="{ hover }">
+    <v-card
+      flat
+      class="pa-0"
+      :aria-label="$t('search.access.to.result', {0 :pageTitleText})"
+      :href="pageUrl">
+      <v-list class="pa-0" :class="hover && 'light-grey-background-color no-border-radius' || ''">
+        <v-list-item>
+          <v-list-item-icon class="me-4">
+            <v-icon size="32" class="icon-default-color mt-2">fas fa-file-alt</v-icon>
+          </v-list-item-icon>
+
+          <v-list-item-content>
+            <v-list-item-title>
+              <h1
+                class="title primary--text pt-1 mb-0 ps-0 my-auto align-center text-start text-truncate"
+                v-sanitized-html="pageTitle">
+              </h1>
+            </v-list-item-title>
+
+            <v-list-item-subtitle class="d-flex flex-column">
+              <span class="d-flex flex-row mx-auto full-width" v-if="pageAuthor || pageDate">
+                <exo-user-avatar
+                  v-if="pageAuthor"
+                  :profile-id="pageAuthor"
+                  :size="18"
+                  small-font-size
+                  :popover="false" />
+                <v-icon
+                  v-if="pageAuthor && pageDate"
+                  size="3"
+                  class="icon-default-color mx-3">fas fa-circle</v-icon>
+                <v-icon
+                  v-if="pageDate"
+                  size="12"
+                  class="icon-default-color">fas fa-clock</v-icon>
+                <date-format v-if="pageDate" class="ms-1 my-auto" :value="pageDate" />
+              </span>
+              <div
+                class="pt-2 text-wrap text-body-2 text-color text-break text-truncate-3"
+                v-sanitized-html="excerpt"></div>
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </v-hover>
+</template>
+
+<script>
+export default {
+  props: {
+    term: {
+      type: String,
+      default: null,
+    },
+    result: {
+      type: Object,
+      default: null,
+    },
+  },
+  computed: {
+    pageUrl() {
+      return this.result?.url || null;
+    },
+    excerpt() {
+      return this.result?.excerpt;
+    },
+    pageTitle() {
+      if (!this.result) {
+        return '';
+      }
+      return this.result.siteName ? `${this.result.title} - ${this.result.siteName}` : this.result.title;
+    },
+    pageTitleText() {
+      return $('<div />').html(this.pageTitle).text();
+    },
+    pageAuthor() {
+      return this.result?.author;
+    },
+    pageDate() {
+      return this.result?.date;
+    },
+  },
+};
+</script>

--- a/notes-webapp/src/main/webapp/vue-app/pageSearch/initComponents.js
+++ b/notes-webapp/src/main/webapp/vue-app/pageSearch/initComponents.js
@@ -1,0 +1,19 @@
+import PageSearchCard from './components/PageSearchCard.vue';
+
+const components = {
+  'page-search-card': PageSearchCard,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}
+
+// get override components if exists
+if (extensionRegistry) {
+  const components = extensionRegistry.loadComponents('PageSearchCard');
+  if (components && components.length > 0) {
+    components.forEach(cmp => {
+      Vue.component(cmp.componentName, cmp.componentOptions);
+    });
+  }
+}

--- a/notes-webapp/src/main/webapp/vue-app/pageSearch/main.js
+++ b/notes-webapp/src/main/webapp/vue-app/pageSearch/main.js
@@ -1,0 +1,5 @@
+import './initComponents.js';
+
+export function formatSearchResult(results) {
+  return results?.jsonList || [];
+}

--- a/notes-webapp/webpack.prod.js
+++ b/notes-webapp/webpack.prod.js
@@ -11,6 +11,7 @@ const config = {
     wikiCkeditor: './src/main/webapp/javascript/eXo/wiki/ckeditor/wikiCkeditor.js',
     pageContent: './src/main/webapp/javascript/eXo/wiki/pageContent.js',
     wikiSearchCard: './src/main/webapp/vue-app/wikiSearch/main.js',
+    pageSearchCard: './src/main/webapp/vue-app/pageSearch/main.js',
     notes: './src/main/webapp/vue-app/notes/main.js',
     notesEditor: './src/main/webapp/vue-app/notes-editor/main.js',
     notesRichEditor: './src/main/webapp/vue-app/notes-rich-editor/main.js',


### PR DESCRIPTION
Add the query-time "page" search connector (ES query against page_content_alias, permission filtering, first-matching-navigation-node URL resolution), its REST endpoint, and the "Pages" filter chip (icon file-alt) with its result card in the unified search UI.