### PR TITLE
feat: contribute Single Note View content to the generic page search index - EXO-88570

### DIFF
--- a/notes-service/src/main/java/io/meeds/notes/listener/NoteContentIndexingListener.java
+++ b/notes-service/src/main/java/io/meeds/notes/listener/NoteContentIndexingListener.java
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.notes.listener;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerBase;
+import org.exoplatform.services.listener.ListenerService;
+
+import io.meeds.notes.service.NotePageViewService;
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.service.CMSService;
+import io.meeds.social.cms.storage.elasticsearch.PageContentIndexingConnector;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Reacts to Notes' {@code note.posted} / {@code note.updated} events to
+ * re-index the portal Page carrying this note as a Single Note View content
+ * block, so Social's generic "page" search index stays in sync when the
+ * note's content (not the page layout) is what changed.
+ * <p>
+ * A note is a Single Note View's content when a {@code notePage}
+ * {@link CMSSetting} exists whose name equals the note's own name (that
+ * invariant is guaranteed by {@link NotePageViewService}, which always
+ * creates such a note as {@code new Page(name, name)}).
+ */
+@Component
+public class NoteContentIndexingListener implements ListenerBase<String, org.exoplatform.wiki.model.Page> {
+
+  @Autowired
+  private ListenerService  listenerService;
+
+  @Autowired
+  private IndexingService  indexingService;
+
+  @Autowired
+  private CMSService       cmsService;
+
+  @Autowired
+  private LayoutService    layoutService;
+
+  @PostConstruct
+  public void init() {
+    listenerService.addListener("note.posted", this);
+    listenerService.addListener("note.updated", this);
+  }
+
+  @Override
+  public void onEvent(Event<String, org.exoplatform.wiki.model.Page> event) throws Exception {
+    org.exoplatform.wiki.model.Page note = event.getData();
+    if (note == null || StringUtils.isBlank(note.getName())) {
+      return;
+    }
+    CMSSetting setting = cmsService.getSettingsByType(NotePageViewService.CMS_CONTENT_TYPE)
+                                   .stream()
+                                   .filter(s -> StringUtils.equals(s.getName(), note.getName()))
+                                   .findFirst()
+                                   .orElse(null);
+    if (setting == null) {
+      return;
+    }
+    Page page = layoutService.getPage(PageKey.parse(setting.getPageReference()));
+    if (page == null) {
+      return;
+    }
+    indexingService.reindex(PageContentIndexingConnector.TYPE, page.getStorageId());
+  }
+
+}

--- a/notes-service/src/main/java/io/meeds/notes/plugin/NotePageContentBlockPlugin.java
+++ b/notes-service/src/main/java/io/meeds/notes/plugin/NotePageContentBlockPlugin.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.notes.plugin;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.wiki.model.Page;
+import org.exoplatform.wiki.utils.Utils;
+
+import io.meeds.notes.service.NotePageViewService;
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.model.PageContentBlock;
+import io.meeds.social.cms.plugin.PageContentBlockPlugin;
+import io.meeds.social.cms.service.PageContentBlockPluginService;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Extracts the content of a Notes "Single Note View" content block so that
+ * Social's generic {@code PageContentIndexingConnector} can index it,
+ * without Social depending on Notes.
+ */
+@Component
+public class NotePageContentBlockPlugin implements PageContentBlockPlugin {
+
+  @Autowired
+  private NotePageViewService        notePageViewService;
+
+  @Autowired
+  private PageContentBlockPluginService pluginService;
+
+  @PostConstruct
+  public void init() {
+    pluginService.addPlugin(this);
+  }
+
+  @Override
+  public String getContentType() {
+    return NotePageViewService.CMS_CONTENT_TYPE;
+  }
+
+  @Override
+  public PageContentBlock getContent(CMSSetting setting) {
+    Map<String, Page> pages = notePageViewService.getNotePages(setting.getName());
+    Page defaultPage = pages.get("");
+    if (defaultPage == null) {
+      return null;
+    }
+    Map<String, String> content = new HashMap<>();
+    pages.forEach((lang, page) -> content.put(lang, Utils.html2text(page.getContent())));
+    Date date = defaultPage.getUpdatedDate() != null ? defaultPage.getUpdatedDate() : defaultPage.getCreatedDate();
+    return new PageContentBlock(defaultPage.getAuthor(), date, content);
+  }
+
+}

--- a/notes-service/src/test/java/io/meeds/notes/listener/NoteContentIndexingListenerTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/listener/NoteContentIndexingListenerTest.java
@@ -1,0 +1,130 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.notes.listener;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.search.index.IndexingService;
+import org.exoplatform.portal.config.model.Page;
+import org.exoplatform.portal.mop.page.PageKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerService;
+
+import io.meeds.notes.service.NotePageViewService;
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.service.CMSService;
+import io.meeds.social.cms.storage.elasticsearch.PageContentIndexingConnector;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NoteContentIndexingListenerTest {
+
+  private static final String                 NOTE_NAME  = "note1";
+
+  private static final PageKey                PAGE_KEY   = PageKey.parse("portal::site::page");
+
+  private static final String                 STORAGE_ID = "page_139";
+
+  @Mock
+  private ListenerService                     listenerService;
+
+  @Mock
+  private IndexingService                     indexingService;
+
+  @Mock
+  private CMSService                          cmsService;
+
+  @Mock
+  private LayoutService                       layoutService;
+
+  @InjectMocks
+  private NoteContentIndexingListener         listener;
+
+  private org.exoplatform.wiki.model.Page     note;
+
+  @Before
+  public void setup() {
+    note = mock(org.exoplatform.wiki.model.Page.class);
+    when(note.getName()).thenReturn(NOTE_NAME);
+  }
+
+  @Test
+  public void shouldRegisterListenersOnInit() {
+    listener.init();
+
+    verify(listenerService).addListener("note.posted", listener);
+    verify(listenerService).addListener("note.updated", listener);
+  }
+
+  @Test
+  public void shouldIgnoreEventWithBlankNoteName() throws Exception {
+    when(note.getName()).thenReturn("");
+
+    listener.onEvent(new Event<>("note.posted", "user", note));
+
+    verify(indexingService, never()).reindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void shouldIgnoreEventWhenNoteIsNotBoundToAPage() throws Exception {
+    when(cmsService.getSettingsByType(NotePageViewService.CMS_CONTENT_TYPE)).thenReturn(Collections.emptyList());
+
+    listener.onEvent(new Event<>("note.updated", "user", note));
+
+    verify(indexingService, never()).reindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void shouldIgnoreEventWhenBoundPageNoLongerExists() throws Exception {
+    CMSSetting setting = new CMSSetting(NotePageViewService.CMS_CONTENT_TYPE, NOTE_NAME, PAGE_KEY.format(), 0);
+    when(cmsService.getSettingsByType(NotePageViewService.CMS_CONTENT_TYPE)).thenReturn(List.of(setting));
+    when(layoutService.getPage(PAGE_KEY)).thenReturn(null);
+
+    listener.onEvent(new Event<>("note.posted", "user", note));
+
+    verify(indexingService, never()).reindex(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void shouldReindexBoundPageWhenNoteContentChanges() throws Exception {
+    CMSSetting setting = new CMSSetting(NotePageViewService.CMS_CONTENT_TYPE, NOTE_NAME, PAGE_KEY.format(), 0);
+    when(cmsService.getSettingsByType(NotePageViewService.CMS_CONTENT_TYPE)).thenReturn(List.of(setting));
+    Page page = mock(Page.class);
+    when(page.getStorageId()).thenReturn(STORAGE_ID);
+    when(layoutService.getPage(PAGE_KEY)).thenReturn(page);
+
+    listener.onEvent(new Event<>("note.updated", "user", note));
+
+    verify(indexingService).reindex(PageContentIndexingConnector.TYPE, STORAGE_ID);
+  }
+
+}

--- a/notes-service/src/test/java/io/meeds/notes/plugin/NotePageContentBlockPluginTest.java
+++ b/notes-service/src/test/java/io/meeds/notes/plugin/NotePageContentBlockPluginTest.java
@@ -1,0 +1,120 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.notes.plugin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.wiki.model.Page;
+
+import io.meeds.notes.service.NotePageViewService;
+import io.meeds.social.cms.model.CMSSetting;
+import io.meeds.social.cms.model.PageContentBlock;
+import io.meeds.social.cms.service.PageContentBlockPluginService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotePageContentBlockPluginTest {
+
+  private static final String              SETTING_NAME = "note1";
+
+  private static final CMSSetting          SETTING      = new CMSSetting(NotePageViewService.CMS_CONTENT_TYPE,
+                                                                          SETTING_NAME,
+                                                                          "portal::site::page",
+                                                                          0);
+
+  @Mock
+  private NotePageViewService              notePageViewService;
+
+  @Mock
+  private PageContentBlockPluginService    pluginService;
+
+  @InjectMocks
+  private NotePageContentBlockPlugin       plugin;
+
+  @Before
+  public void setup() {
+    when(notePageViewService.getNotePages(SETTING_NAME)).thenReturn(Map.of());
+  }
+
+  @Test
+  public void shouldRegisterItselfOnInit() {
+    plugin.init();
+
+    org.mockito.Mockito.verify(pluginService).addPlugin(plugin);
+  }
+
+  @Test
+  public void shouldExposeNotePageContentType() {
+    assertEquals(NotePageViewService.CMS_CONTENT_TYPE, plugin.getContentType());
+  }
+
+  @Test
+  public void shouldReturnNullWhenNoDefaultLanguagePageExists() {
+    assertNull(plugin.getContent(SETTING));
+  }
+
+  @Test
+  public void shouldExtractPlainTextContentPerLanguageUsingUpdatedDate() {
+    Page defaultPage = mock(Page.class);
+    when(defaultPage.getAuthor()).thenReturn("john");
+    Date updatedDate = new Date();
+    when(defaultPage.getUpdatedDate()).thenReturn(updatedDate);
+    when(defaultPage.getContent()).thenReturn("<p>Hello</p>");
+
+    Page frenchPage = mock(Page.class);
+    when(frenchPage.getContent()).thenReturn("<p>Bonjour</p>");
+
+    when(notePageViewService.getNotePages(SETTING_NAME)).thenReturn(Map.of("", defaultPage, "fr", frenchPage));
+
+    PageContentBlock content = plugin.getContent(SETTING);
+
+    assertEquals("john", content.getAuthor());
+    assertEquals(updatedDate, content.getDate());
+    assertEquals("Hello", content.getContent().get(""));
+    assertEquals("Bonjour", content.getContent().get("fr"));
+  }
+
+  @Test
+  public void shouldFallBackToCreatedDateWhenNeverUpdated() {
+    Page defaultPage = mock(Page.class);
+    when(defaultPage.getContent()).thenReturn("<p>Hello</p>");
+    when(defaultPage.getUpdatedDate()).thenReturn(null);
+    Date createdDate = new Date();
+    when(defaultPage.getCreatedDate()).thenReturn(createdDate);
+
+    when(notePageViewService.getNotePages(SETTING_NAME)).thenReturn(Map.of("", defaultPage));
+
+    PageContentBlock content = plugin.getContent(SETTING);
+
+    assertEquals(createdDate, content.getDate());
+  }
+
+}


### PR DESCRIPTION
- NotePageContentBlockPlugin: implements Social's PageContentBlockPlugin to extract a Single Note View note's author, date and per-language plain-text content for indexing.
- NoteContentIndexingListener: reacts to note.posted/note.updated to re-trigger indexing via Social's PageContentIndexingConnector when the note's content changes (independently of page layout changes).