### PR TITLE
fix: Note fiter field hasn't a label - EXO-88599

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -137,6 +137,7 @@ popup.confirmation.cancel=Are you sure you want to leave this page?
 notes.label.breadcrumbTitle=Notes Tree
 notes.label.breadcrumbs=Breadcrumb
 notes.label.filter=Filter by name
+notes.label.filter.placeholder=Start searching note page
 notes.label.resetFilter=Reset
 notes.label.includePageTitle=Include Notes
 notes.label.movePageTitle=Move Page

--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewDrawer.vue
@@ -306,7 +306,9 @@
             <div class="flex-grow-1 me-2 d-flex content-box-sizing">
               <v-text-field
                 v-model="search"
-                :placeholder=" $t('notes.label.filter') "
+                :placeholder="$t('notes.label.filter.placeholder')"
+                :aria-label="$t('notes.label.filter')"
+                :title="$t('notes.label.filter')"
                 class="search mt-auto"
                 clearable
                 hide-details

--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
@@ -24,7 +24,8 @@
       id="noteTreeviewToolbar"
       :right-text-filter="{
         minCharacters: 3,
-        placeholder: $t('notes.label.filter'),
+        placeholder: $t('notes.label.filter.placeholder'),
+        ariaLabel: $t('notes.label.filter'),
         tooltip: $t('notes.label.filter')
       }"
       :right-filter-button=" {


### PR DESCRIPTION
Before this change, when access to note application and click on the fiter button, the filter field hasn't a label. After this change, aria-label=Filter by name, title=Filter by name and placeholder label to Start searching note page.
