### PR TITLE
fix: Remove custom tooltip from Note filter field - EXO-88599

### DIFF
--- a/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
+++ b/notes-webapp/src/main/webapp/vue-app/notes-treeview/components/NoteTreeviewToolbar.vue
@@ -26,7 +26,6 @@
         minCharacters: 3,
         placeholder: $t('notes.label.filter.placeholder'),
         ariaLabel: $t('notes.label.filter'),
-        tooltip: $t('notes.label.filter')
       }"
       :right-filter-button=" {
         text: $t('notes.advanced.filter.button.title'),


### PR DESCRIPTION
A native tooltip is already displayed via the title attribute on the filter input, so the custom `tooltip` is redundant.
