### PR TITLE
fix: Reindex inserted note links reliably on notebook import - EXO-88788

### DIFF
--- a/notes-service/src/main/java/org/exoplatform/wiki/service/ExportThread.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/ExportThread.java
@@ -453,6 +453,11 @@ import io.meeds.notes.model.NotePageProperties;
     } catch (Exception e) {
       log.warn("Cannot process notes link for note {}", note.getId());
     }
+    try {
+      note.setContent(processInsertedNotes(note.getContent()));
+    } catch (Exception e) {
+      log.warn("Cannot process inserted notes for note {}", note.getId());
+    }
     ExportResource exportResource = notesExportService.getExportRessourceById(exportId);
     if (exportResource != null) {
       exportResource.setExportedNotesCount(exportResource.getExportedNotesCount() + 1);

--- a/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
+++ b/notes-service/src/main/java/org/exoplatform/wiki/service/impl/NoteServiceImpl.java
@@ -1362,16 +1362,18 @@ public class NoteServiceImpl implements NoteService {
           }
         }
       }
+      Map<String, String> importedNotesIdsByName = new HashMap<>();
       for (Page note : notes.getNotes()) {
         importNote(note,
                    parent,
                    featuredImages,
                    wikiService.getWikiByTypeAndOwner(parent.getWikiType(), parent.getWikiOwner()),
                    conflict,
-                   userIdentity);
+                   userIdentity,
+                   importedNotesIdsByName);
       }
       for (Page note : notes.getNotes()) {
-        replaceInsertedNotes(note, wiki, userIdentity);
+        replaceInsertedNotes(note, wiki, userIdentity, importedNotesIdsByName);
         replaceIncludedPages(note, wiki, userIdentity);
       }
       cleanUp(notesFile);
@@ -1958,9 +1960,11 @@ public class NoteServiceImpl implements NoteService {
                           Map<String, String> featuredImages,
                           Wiki wiki,
                           String conflict,
-                          Identity userIdentity) throws Exception {
+                          Identity userIdentity,
+                          Map<String, String> importedNotesIdsByName) throws Exception {
 
     Page targetNote = null;
+    String originalNoteName = note.getName();
     File featuredImageFile = extractNoteFeaturedImageFileToImport(note, featuredImages);
     Page parent_ = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), parent.getName());
     if (parent_ == null) {
@@ -2012,9 +2016,16 @@ public class NoteServiceImpl implements NoteService {
                                 targetNote,
                                 Long.parseLong(identityManager.getOrCreateUserIdentity(userIdentity.getUserId()).getId()));
     }
+    Page importedNote = targetNote;
+    if (importedNote == null) {
+      importedNote = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), note.getName());
+    }
+    if (importedNote != null && importedNote.getId() != null && StringUtils.isNotEmpty(originalNoteName)) {
+      importedNotesIdsByName.put(originalNoteName, importedNote.getId());
+    }
     if (note.getChildren() != null) {
       for (Page child : note.getChildren()) {
-        importNote(child, note_, featuredImages, wiki, conflict, userIdentity);
+        importNote(child, note_, featuredImages, wiki, conflict, userIdentity, importedNotesIdsByName);
       }
     }
   }
@@ -2146,8 +2157,8 @@ public class NoteServiceImpl implements NoteService {
     }
   }
 
-  private void replaceInsertedNotes(Page note, Wiki wiki, Identity userIdentity) {
-    Page note_ = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), note.getName());
+  private void replaceInsertedNotes(Page note, Wiki wiki, Identity userIdentity, Map<String, String> importedNotesIdsByName) {
+    Page note_ = resolveImportedNote(note.getName(), wiki, importedNotesIdsByName);
     if (note_ != null) {
       String content = note_.getContent();
       Pattern pattern = Pattern.compile("(<)" + CONTENT_LINK_TAG_REPLACEMENT + "([^>]*?>/notes:)([^<]+)(</)" + CONTENT_LINK_TAG_REPLACEMENT + "(>)");
@@ -2155,7 +2166,7 @@ public class NoteServiceImpl implements NoteService {
       StringBuilder result = new StringBuilder();
       while (matcher.find()) {
         String noteName = matcher.group(3);
-        Page noteToInsert = getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), noteName);
+        Page noteToInsert = resolveImportedNote(noteName, wiki, importedNotesIdsByName);
         String noteId = "0";
         if (noteToInsert != null) {
           noteId = matcher.group(1) + CONTENT_LINK_TAG + matcher.group(2)
@@ -2173,9 +2184,23 @@ public class NoteServiceImpl implements NoteService {
     }
     if (note.getChildren() != null) {
       for (Page child : note.getChildren()) {
-        replaceInsertedNotes(child, wiki, userIdentity);
+        replaceInsertedNotes(child, wiki, userIdentity, importedNotesIdsByName);
       }
     }
+  }
+
+  private Page resolveImportedNote(String noteName, Wiki wiki, Map<String, String> importedNotesIdsByName) {
+    if (StringUtils.isEmpty(noteName)) {
+      return null;
+    }
+    String importedId = importedNotesIdsByName == null ? null : importedNotesIdsByName.get(noteName);
+    if (importedId != null) {
+      Page note = getNoteById(importedId);
+      if (note != null) {
+        return note;
+      }
+    }
+    return getNoteOfNoteBookByName(wiki.getType(), wiki.getOwner(), noteName);
   }
 
   private void addAllNodes(Page note, List<Page> listOfNotes) throws WikiException {

--- a/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
+++ b/notes-service/src/test/java/org/exoplatform/wiki/service/TestNoteService.java
@@ -609,6 +609,45 @@ public class TestNoteService extends BaseTest {
     assertEquals(noteService.getChildrenNoteOf(userWiki.getWikiHome(), false, false).size(), childern + 3);
   }
 
+  public void testImportNotesReindexesInsertedNoteLinks() throws Exception {
+    Wiki portalWiki = getOrCreateWiki(wikiService, PortalConfig.PORTAL_TYPE, PORTAL_NAME);
+    Page target = noteService.createNote(portalWiki, "Home", new Page("insert_target", "insert_target"), ROOT_IDENTITY);
+    Page source = new Page("insert_source", "insert_source");
+    // Note referencing another note through the "insert note" feature (content-link)
+    source.setContent("<content-link class=\"navigationContentLink\">/notes:" + target.getId() + "</content-link>");
+    source = noteService.createNote(portalWiki, "Home", source, ROOT_IDENTITY);
+
+    // Export the whole notebook (exportAll = true)
+    String[] notes = new String[] { target.getId(), source.getId() };
+    File zipFile = File.createTempFile("notesExportInserted", ".zip");
+    notesExportService.startExportNotes(200232, notes, true, ROOT_IDENTITY);
+    boolean exportDone = false;
+    while (!exportDone) {
+      if (notesExportService.getStatus(200232).getStatus().equals("ZIP_CREATED")) {
+        exportDone = true;
+      }
+    }
+    byte[] exportedNotes = notesExportService.getExportedNotes(200232);
+    assertNotNull(exportedNotes);
+    FileUtils.writeByteArrayToFile(zipFile, exportedNotes);
+
+    // Import into another notebook
+    Wiki userWiki = getOrCreateWiki(wikiService, PortalConfig.USER_TYPE, "root");
+    noteService.importNotes(zipFile.getPath(), userWiki.getWikiHome(), "update", ROOT_IDENTITY);
+    assertTrue(zipFile.delete());
+
+    Page importedTarget = noteService.getNoteOfNoteBookByName(PortalConfig.USER_TYPE, "root", target.getName());
+    Page importedSource = noteService.getNoteOfNoteBookByName(PortalConfig.USER_TYPE, "root", source.getName());
+    assertNotNull(importedTarget);
+    assertNotNull(importedSource);
+    // The inserted note link must be reindexed to the imported target note id
+    assertTrue("Inserted note link should be reindexed to the imported note id",
+               importedSource.getContent().contains("/notes:" + importedTarget.getId() + "</content-link>"));
+    // It must no longer point to the old (source environment) note id, which would render as "Content deleted"
+    assertFalse("Inserted note link should not keep the old note id",
+                importedSource.getContent().contains("/notes:" + target.getId() + "</content-link>"));
+  }
+
   public void testGetNotesOfWiki() throws WikiException, IllegalAccessException {
     Wiki portalWiki = getOrCreateWiki(wikiService, PortalConfig.PORTAL_TYPE, PORTAL_NAME);
     Page toBeImported1NotPage = noteService.createNote(portalWiki,


### PR DESCRIPTION
Inserted note links were rendered as "Content has been deleted" after import, mostly for notes whose names contain special characters (accents, dots, ...).
- Export: apply processInsertedNotes() in the "export all" path so links are converted to reindex markers like the per-note export.
- Import: resolve links against a name -> id map of the imported notes (by id), instead of a name based lookup that is unreliable for special characters. Links to notes not included in the export stay unresolved, as there is no target to reindex them to.
