### PR TITLE
fix: backport missing keys in stable/7.2.x - EXO-88872

### DIFF
--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ar.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ar.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_aro.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_aro.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ca.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ca.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_co.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_co.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_cs.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_cs.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_de.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_de.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Bereit? Los geht's!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_el.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_el.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_es_ES.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_es_ES.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_et.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_et.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fa.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fa.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fi.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fil.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fil.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_fr.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Prêt ? Allons-y !
 
 
 
+notes.label.myNotes=Mes Notes
+notes.menu.label.manageCategories=Gérer les catégories
+notes.menu.label.manageCategories.success=Catégories mises à jour avec succès
+notes.menu.label.manageCategories.error=Erreur lors de la mise à jour des catégories
+notes.editor.restrictedTitle=Accès restreint
+notes.editor.restrictedDescription=Seuls les rédacteurs peuvent modifier ce contenu
+notes.editor.restrictedButton=Retour à l'accueil
+notes.button.apply=Appliquer
+notes.reorder.success.message=Note réordonnée avec succès
+notes.reorder.error.message=Erreur lors de la réorganisation de la note
+notes.publication.category.label=Catégories
+notes.publication.category.add.label=Ajouter une catégorie
+notes.label.filter.placeholder=Rechercher une note
+notes.label.resetFilter=Réinitialiser
+notes.label.noResults.placeholder=Aucun résultat trouvé. S'il vous plaît, réessayez
+notes.label.tree=Arborescence
+notes.tooltip.close.tree=Cacher l'arborescence
+notes.tooltip.open.tree=Afficher l'arborescence
+notes.advanced.filter.button.title=Filtre
+notes.advanced.filter.drawer.title=Filtrer les notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_he.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_he.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_hr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_hr.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_hu.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_hu.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_id.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_id.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_it.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_it.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ja.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ja.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ko.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ko.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_lt.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_lt.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_nl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_nl.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_no.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_no.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_pl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_pl.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_pt_BR.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_pt_BR.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Pronto? Vamos lá!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_pt_PT.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_pt_PT.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ro.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ro.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ru.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_ru.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sk.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sk.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sl.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sl.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sq.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sq.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=crwdns102267:0crwdne102267:0
 
 
 
+notes.label.myNotes=crwdns115640:0crwdne115640:0
+notes.menu.label.manageCategories=crwdns117445:0crwdne117445:0
+notes.menu.label.manageCategories.success=crwdns117447:0crwdne117447:0
+notes.menu.label.manageCategories.error=crwdns117449:0crwdne117449:0
+notes.editor.restrictedTitle=crwdns117035:0crwdne117035:0
+notes.editor.restrictedDescription=crwdns117037:0crwdne117037:0
+notes.editor.restrictedButton=crwdns117039:0crwdne117039:0
+notes.button.apply=crwdns116000:0crwdne116000:0
+notes.reorder.success.message=crwdns116002:0crwdne116002:0
+notes.reorder.error.message=crwdns116004:0crwdne116004:0
+notes.publication.category.label=crwdns117451:0crwdne117451:0
+notes.publication.category.add.label=crwdns117453:0crwdne117453:0
+notes.label.filter.placeholder=crwdns117525:0crwdne117525:0
+notes.label.resetFilter=crwdns116006:0crwdne116006:0
+notes.label.noResults.placeholder=crwdns116008:0crwdne116008:0
+notes.label.tree=crwdns116010:0crwdne116010:0
+notes.tooltip.close.tree=crwdns116012:0crwdne116012:0
+notes.tooltip.open.tree=crwdns116014:0crwdne116014:0
+notes.advanced.filter.button.title=crwdns116016:0crwdne116016:0
+notes.advanced.filter.drawer.title=crwdns116018:0crwdne116018:0

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sv_SE.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_sv_SE.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_th.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_th.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_tr.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_tr.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_uk.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_uk.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_vi.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_vi.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_zh_CN.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_zh_CN.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes

--- a/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_zh_TW.properties
+++ b/notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_zh_TW.properties
@@ -285,3 +285,23 @@ notes.terms.reminder.letsGo=Ready? Let's go!
 
 
 
+notes.label.myNotes=My Notes
+notes.menu.label.manageCategories=Manage categories
+notes.menu.label.manageCategories.success=Categories successfully updated
+notes.menu.label.manageCategories.error=Error while updating categories
+notes.editor.restrictedTitle=Restricted Area
+notes.editor.restrictedDescription=Only redactors can edit this content
+notes.editor.restrictedButton=Back to Home
+notes.button.apply=Apply
+notes.reorder.success.message=Note reordered successfully
+notes.reorder.error.message=Error when reordering note
+notes.publication.category.label=Category
+notes.publication.category.add.label=Add category
+notes.label.filter.placeholder=Start searching note page
+notes.label.resetFilter=Reset
+notes.label.noResults.placeholder=No results found. please, Try again
+notes.label.tree=Treeview
+notes.tooltip.close.tree=Hide treeview
+notes.tooltip.open.tree=Display treeview
+notes.advanced.filter.button.title=Filter
+notes.advanced.filter.drawer.title=Filter notes


### PR DESCRIPTION
Backports translation keys that exist on `develop` but are missing on `stable/7.2.x-exo`, for the subset whose corresponding feature code is already present on this branch (verified before backporting to avoid orphaned strings).

Files changed:
  notes-webapp/src/main/resources/locale/portlet/notes/notesPortlet_en.properties: +20 key(s)

Ref: EXO-88872